### PR TITLE
Fix softmax, layernorm, rmsnorm

### DIFF
--- a/ark/ops/ops_rmsnorm_test.cc
+++ b/ark/ops/ops_rmsnorm_test.cc
@@ -24,21 +24,21 @@ void baseline_rmsnorm(std::vector<void *> &outputs,
     for (ark::DimType n = 0; n < ish[0]; ++n) {
         for (ark::DimType c = 0; c < ish[1]; ++c) {
             for (ark::DimType h = 0; h < ish[2]; ++h) {
-                T square_sum = 0;
+                float square_sum = 0;
                 for (ark::DimType w = 0; w < ish[3]; ++w) {
-
-                    T val = input[n * ish[1] * ish[2] * ish[3] +
-                                  c * ish[2] * ish[3] + h * ish[3] + w];
+                    float val =
+                        float(input[n * ish[1] * ish[2] * ish[3] +
+                                    c * ish[2] * ish[3] + h * ish[3] + w]);
                     square_sum += val * val;
                 }
-                T eps = 1e-5;
-                T rms = (T)sqrt((float)square_sum / ish[3]) + eps;
+                float eps = 1e-5;
+                float rms = std::sqrt(square_sum / ish[3]) + eps;
                 for (ark::DimType w = 0; w < ish[3]; ++w) {
                     out[n * osh[1] * osh[2] * osh[3] + c * osh[2] * osh[3] +
                         h * osh[3] + w] =
-                        input[n * osh[1] * osh[2] * osh[3] +
-                              c * osh[2] * osh[3] + h * osh[3] + w] /
-                        rms;
+                        T(float(input[n * osh[1] * osh[2] * osh[3] +
+                                      c * osh[2] * osh[3] + h * osh[3] + w]) /
+                          rms);
                 }
             }
         }
@@ -48,10 +48,10 @@ void baseline_rmsnorm(std::vector<void *> &outputs,
 ark::unittest::State test_rmsnorm_fp32()
 {
     ark::Model m;
-    ark::Tensor *t = m.tensor(ark::Dims(1, 32, 32, 256), ark::FP32);
+    ark::Tensor *t = m.tensor(ark::Dims(1, 32, 32, 8192), ark::FP32);
     ark::Tensor *out = m.rmsnorm(t);
     auto result =
-        ark::op_test("rmsnorm", m, {t}, {out}, baseline_rmsnorm<float>);
+        ark::op_test("rmsnorm_fp32", m, {t}, {out}, baseline_rmsnorm<float>);
     ark::op_test_log(result);
     return ark::unittest::SUCCESS;
 }
@@ -59,9 +59,9 @@ ark::unittest::State test_rmsnorm_fp32()
 ark::unittest::State test_rmsnorm_fp16()
 {
     ark::Model model;
-    ark::Tensor *input = model.tensor(ark::Dims(1, 32, 32, 256), ark::FP16);
+    ark::Tensor *input = model.tensor(ark::Dims(1, 32, 32, 8192), ark::FP16);
     ark::Tensor *output = model.rmsnorm(input);
-    auto result = ark::op_test("rmsnorm", model, {input}, {output},
+    auto result = ark::op_test("rmsnorm_fp16", model, {input}, {output},
                                baseline_rmsnorm<ark::half_t>);
     ark::op_test_log(result);
     return ark::unittest::SUCCESS;

--- a/ark/ops/ops_softmax_test.cc
+++ b/ark/ops/ops_softmax_test.cc
@@ -22,17 +22,27 @@ void baseline_softmax(std::vector<void *> &outputs,
     for (ark::DimType n = 0; n < ish[0]; ++n) {
         for (ark::DimType c = 0; c < ish[1]; ++c) {
             for (ark::DimType h = 0; h < ish[2]; ++h) {
-                T sum = 0;
+                float maxval = std::numeric_limits<float>::lowest();
                 for (ark::DimType w = 0; w < ish[3]; ++w) {
-                    sum += std::exp(input[w + h * ish[3] + c * ish[2] * ish[3] +
-                                          n * ish[1] * ish[2] * ish[3]]);
+                    float val =
+                        float(input[w + h * ish[3] + c * ish[2] * ish[3] +
+                                    n * ish[1] * ish[2] * ish[3]]);
+                    if (val > maxval) {
+                        maxval = val;
+                    }
+                }
+                float sum = 0;
+                std::vector<float> exps(ish[3]);
+                for (ark::DimType w = 0; w < ish[3]; ++w) {
+                    exps[w] = std::exp(
+                        float(input[w + h * ish[3] + c * ish[2] * ish[3] +
+                                    n * ish[1] * ish[2] * ish[3]]) -
+                        maxval);
+                    sum += exps[w];
                 }
                 for (ark::DimType w = 0; w < ish[3]; ++w) {
                     out[w + h * osh[3] + c * osh[2] * osh[3] +
-                        n * osh[1] * osh[2] * osh[3]] =
-                        std::exp(input[w + h * ish[3] + c * ish[2] * ish[3] +
-                                       n * ish[1] * ish[2] * ish[3]]) /
-                        sum;
+                        n * osh[1] * osh[2] * osh[3]] = T(exps[w] / sum);
                 }
             }
         }
@@ -42,11 +52,85 @@ void baseline_softmax(std::vector<void *> &outputs,
 ark::unittest::State test_softmax_fp32()
 {
     ark::Model m;
-    ark::Tensor *t = m.tensor(ark::Dims(2, 8192), ark::FP32);
+    ark::Tensor *t = m.tensor(ark::Dims(64, 8192), ark::FP32);
     ark::Tensor *out = m.softmax(t);
 
     auto result =
-        ark::op_test("reduce_axis3", m, {t}, {out}, baseline_softmax<float>);
+        ark::op_test("softmax_fp32", m, {t}, {out}, baseline_softmax<float>);
+    ark::op_test_log(result);
+    return ark::unittest::SUCCESS;
+}
+
+ark::unittest::State test_softmax_fp16()
+{
+    {
+        ark::Model m;
+        ark::Tensor *t = m.tensor(ark::Dims(64, 8192), ark::FP16);
+        ark::Tensor *out = m.softmax(t);
+
+        auto result = ark::op_test("softmax_fp16", m, {t}, {out},
+                                   baseline_softmax<ark::half_t>);
+        ark::op_test_log(result);
+    }
+    {
+        ark::Model m;
+        ark::Tensor *t = m.tensor(ark::Dims(1, 32, 64, 64), ark::FP16);
+        ark::Tensor *out = m.softmax(t);
+
+        auto result = ark::op_test("softmax_fp16", m, {t}, {out},
+                                   baseline_softmax<ark::half_t>);
+        ark::op_test_log(result);
+    }
+    return ark::unittest::SUCCESS;
+}
+
+ark::unittest::State test_softmax_fp16_padded()
+{
+    ark::Model m;
+    ark::Tensor *t =
+        m.tensor(ark::Dims(2, 4), ark::FP16, nullptr, ark::Dims(2, 8));
+    ark::Tensor *out = m.softmax(t);
+
+    auto result = ark::op_test("softmax_fp16_padded", m, {t}, {out},
+                               baseline_softmax<ark::half_t>);
+    ark::op_test_log(result);
+    return ark::unittest::SUCCESS;
+}
+
+ark::unittest::State test_softmax_fp16_big_magnitude()
+{
+    ark::Model model;
+    ark::Tensor *input = model.tensor(ark::Dims(1, 32, 32, 8192), ark::FP16);
+    ark::Tensor *output = model.softmax(input);
+
+    // set input to a big magnitude
+    std::vector<ark::half_t> input_data;
+    for (ark::DimType i = 0; i < input->shape.size(); ++i) {
+        // larger to smaller
+        input_data.push_back(ark::half_t((2047 - i) % 2048 - 1024));
+    }
+
+    auto result = ark::op_test("softmax_fp16_big_magnitude", model, {input},
+                               {output}, baseline_softmax<ark::half_t>);
+    ark::op_test_log(result);
+    return ark::unittest::SUCCESS;
+}
+
+ark::unittest::State test_softmax_fp16_small_magnitude()
+{
+    ark::Model model;
+    ark::Tensor *input = model.tensor(ark::Dims(1, 32, 32, 8192), ark::FP16);
+    ark::Tensor *output = model.softmax(input);
+
+    // set input to a small magnitude
+    std::vector<ark::half_t> input_data;
+    for (ark::DimType i = 0; i < input->shape.size(); ++i) {
+        // larger to smaller
+        input_data.push_back(ark::half_t(((2047 - i) % 2048 - 1024) * 1e-7f));
+    }
+
+    auto result = ark::op_test("softmax_fp16_small_magnitude", model, {input},
+                               {output}, baseline_softmax<ark::half_t>);
     ark::op_test_log(result);
     return ark::unittest::SUCCESS;
 }
@@ -55,5 +139,9 @@ int main()
 {
     ark::init();
     UNITTEST(test_softmax_fp32);
+    UNITTEST(test_softmax_fp16);
+    UNITTEST(test_softmax_fp16_padded);
+    UNITTEST(test_softmax_fp16_big_magnitude);
+    UNITTEST(test_softmax_fp16_small_magnitude);
     return ark::unittest::SUCCESS;
 }


### PR DESCRIPTION
* Fix indexing errors when the output `ldims` is different from the input `ldims`
* Use Kahan sum by default (TODO: apply for layernorm)