### PR TITLE
pass external buffer ptrs as kernel args

### DIFF
--- a/ark/codegen.hpp
+++ b/ark/codegen.hpp
@@ -15,7 +15,9 @@ namespace ark {
 class CodeGenerator {
    public:
     CodeGenerator(const PlanJson &plan,
-                  const std::map<size_t, void *> &buffer_id_to_addr,
+                  const std::map<size_t, size_t> &buffer_id_to_offset,
+                  const std::vector<std::string> &external_args,
+                  const std::map<size_t, std::string> &buffer_id_to_name,
                   const std::string &name = "ark_kernel");
 
     ~CodeGenerator() = default;

--- a/ark/include/kernels/kernel_template.in
+++ b/ark/include/kernels/kernel_template.in
@@ -6,8 +6,8 @@ using namespace ark;
 template <size_t ProcBegin, size_t ProcEnd, size_t ProcStep, size_t ProcCurrent,
           size_t TaskBegin, size_t TaskEnd, size_t TaskStep, size_t TaskGranularity,
           size_t NumSlots, size_t SlotNumWarps, size_t SlotSramBytes,
-          void (*task)(int, int)>
-__forceinline__ __device__ void task_seq() {
+          void (*task)(char*, int, int, @GLOBAL_ARGS@)>
+__forceinline__ __device__ void task_seq(char *_buf, @GLOBAL_ARGS@) {
   if (math::geq<ProcBegin>(blockIdx.x) && math::le<ProcEnd>(blockIdx.x) &&
       ((blockIdx.x - ProcBegin) % ProcStep == 0)) {
     constexpr size_t SlotNumThreads = SlotNumWarps * Arch::ThreadsPerWarp;
@@ -23,7 +23,7 @@ __forceinline__ __device__ void task_seq() {
       size_t task_id = task_id_base + TaskStep *
         (t % TaskGranularity + t / TaskGranularity * TaskGranularity * NumProcs);
       if (task_id >= TaskEnd) break;
-      task(task_id, SramBytesPerWarp);
+      task(_buf, task_id, SramBytesPerWarp, @GLOBAL_ARGS@);
     }
   }
 }
@@ -33,12 +33,12 @@ __device__ sync::State ARK_LOOP_SYNC_STATE;
 
 @DEFINITIONS@
 
-__device__ void ark_body(int _iter) {
+__device__ void ark_body(char *_buf, int _iter, @GLOBAL_ARGS@) {
 @BODY@
 }
 
 extern "C" __global__ __launch_bounds__(ARK_WARPS_PER_BLOCK * Arch::ThreadsPerWarp, 1)
-void ark_loop_kernel@NAME@(int *_iter) {
+void ark_loop_kernel@NAME@(char *_buf, int *_iter, @GLOBAL_ARGS@) {
   int *shared_mem = (int *)_ARK_SMEM;
   for (int i = threadIdx.x; i < ARK_SMEM_RESERVED_BYTES / sizeof(int); i += blockDim.x) {
     shared_mem[i] = 0;
@@ -52,10 +52,10 @@ void ark_loop_kernel@NAME@(int *_iter) {
     sync_gpu<@NUM_BLOCKS@>(ARK_LOOP_SYNC_STATE);
     if (ARK_ITER < 0) return;
 
-    ark_body(0);
+    ark_body(_buf, 0, @GLOBAL_ARGS@);
     for (int _i = 1; _i < ARK_ITER; ++_i) {
       sync_gpu<@NUM_BLOCKS@>(ARK_LOOP_SYNC_STATE);
-      ark_body(_i);
+      ark_body(_buf, _i, @GLOBAL_ARGS@);
     }
     if (threadIdx.x == 0) {
       __threadfence_system();
@@ -74,5 +74,5 @@ void ark_kernel@NAME@(int _iter) {
   for (int i = threadIdx.x; i < ARK_SMEM_RESERVED_BYTES / sizeof(int); i += blockDim.x) {
     shared_mem[i] = 0;
   }
-  ark_body(_iter);
+  ark_body(_buf, _iter, @GLOBAL_ARGS@);
 }


### PR DESCRIPTION
* Don't use direct memory address in kernel code.
* Use current buffer pointer offsets if a buffer is used in the current plan, otherwise pass the pointer to the buffer as a kernel argument (i.e. the buffer is allocated by PyTorch or used in a previous plan). 