### PR TITLE
Add Placeholder Operator

### DIFF
--- a/ark/include/ark/executor.hpp
+++ b/ark/include/ark/executor.hpp
@@ -9,6 +9,7 @@
 #include <ark/tensor.hpp>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace ark {
@@ -45,10 +46,13 @@ class Executor {
                  const std::string &name = "executor");
 
     /// Launch the executor. This must be called after `compile()`.
-    void launch(Stream stream = nullptr, bool loop_mode = true);
+    void launch(
+        Stream stream = nullptr, bool loop_mode = true,
+        const std::unordered_map<Tensor, void *> &external_tensors = {});
 
     /// Run the executor for `iter` iterations.
-    void run(int iter);
+    void run(int iter,
+             const std::unordered_map<Tensor, void *> &external_tensors = {});
 
     /// Wait for the previous run to finish.
     void wait(int64_t max_spin_count = -1);
@@ -99,10 +103,11 @@ class Model;
 
 class DefaultExecutor : public Executor {
    public:
-    DefaultExecutor(
-        const Model &model, int device_id = -1, Stream stream = nullptr,
-        const std::vector<Planner::ConfigRule> &config_rules = {},
-        const std::string &name = "DefaultExecutor", bool loop_mode = true);
+    DefaultExecutor(const Model &model, int device_id = -1,
+                    Stream stream = nullptr,
+                    const std::vector<Planner::ConfigRule> &config_rules = {},
+                    const std::string &name = "DefaultExecutor",
+                    bool loop_mode = true);
 
     /// Launch the default executor.
     void launch();

--- a/ark/include/ark/model.hpp
+++ b/ark/include/ark/model.hpp
@@ -76,6 +76,39 @@ class Model : public ModelGraph {
                   const Dims &padded_shape = {}, int rank = -1,
                   const std::string &name = "");
 
+    ///
+    /// Returns a tensor object associated with an external buffer.
+    ///
+    /// @param shape Shape of the tensor, where the data of interest is.
+    /// @param dtype Type of the tensor data.
+    /// @param strides Strides of each dimension of the tensor, which may be
+    /// different from the shape. @p strides can be considered as the actual
+    /// shape of the underlying data buffer.
+    /// @param offsets Offsets of the tensor. The data of interest starts at
+    /// @p offsets and ends at @p offsets + @p padded_shape.
+    /// @param padded_shape Padded shape of the tensor. Padding is used to
+    /// reserve extra space for the tensor when computation requires it.
+    /// Data on the padded region is allowed to be accessed by computation,
+    /// but it is not considered as the data of interest. The padded region is
+    /// initialized to zero only once when the Executor is launched. The padded
+    /// shape should be greater than or equal to the @p shape, and the
+    /// @p strides should be greater than or equal to the padded shape. If the
+    /// @p strides are not provided, they are set to the padded shape. If the
+    /// padded shape is not provided, it is set to the @p shape.
+    /// @param rank Rank of the tensor. -1 means the rank of this model.
+    /// @param name Name of the tensor.
+    /// @param external_data Pointer to an external data buffer. If provided,
+    /// this buffer is registered with the ModelBufferManager and associated
+    /// with the tensor.
+    /// @return Pointer to a tensor object that references the external buffer.
+    ///
+    ///
+    Tensor placeholder(const Dims &shape, const DataType &data_type,
+                       const Dims &strides = {}, const Dims &offsets = {},
+                       const Dims &padded_shape = {}, int rank = -1,
+                       const std::string &name = "",
+                       void *external_data = nullptr);
+
     Tensor refer(Tensor input, const Dims &shape = {}, const Dims &strides = {},
                  const Dims &offsets = {}, const Dims &padded_shape = {},
                  const std::string &name = "");
@@ -254,7 +287,6 @@ class Model : public ModelGraph {
 
     Tensor local_all_reduce(Tensor input, int gpu_id, int gpu_num,
                             const std::string &name = "");
-
 };
 
 }  // namespace ark

--- a/ark/include/ark/tensor.hpp
+++ b/ark/include/ark/tensor.hpp
@@ -54,6 +54,8 @@ class Tensor {
     const DataType &data_type() const;
 
     Dims torch_strides() const;
+
+    friend struct std::hash<Tensor>;
 };
 
 const Tensor NullTensor;
@@ -61,5 +63,14 @@ const Tensor NullTensor;
 std::ostream &operator<<(std::ostream &os, const Tensor &tensor);
 
 }  // namespace ark
+
+namespace std {
+template <>
+struct hash<ark::Tensor> {
+    size_t operator()(const ark::Tensor &t) const {
+        return hash<size_t>()(t.id());
+    }
+};
+}  // namespace std
 
 #endif  // ARK_TENSOR_HPP

--- a/ark/model/model_op.cpp
+++ b/ark/model/model_op.cpp
@@ -16,6 +16,7 @@
 #include "ops/ops_math.hpp"
 #include "ops/ops_matmul.hpp"
 #include "ops/ops_noop.hpp"
+#include "ops/ops_placeholder.hpp"
 #include "ops/ops_reduce.hpp"
 #include "ops/ops_refer.hpp"
 #include "ops/ops_reshape.hpp"
@@ -78,6 +79,7 @@ const ModelOpType ModelOpT::from_name(const std::string &type_name) {
         MODEL_OP_TYPE_REGISTER(Sqrt);
         MODEL_OP_TYPE_REGISTER(Sub);
         MODEL_OP_TYPE_REGISTER(Tensor);
+        MODEL_OP_TYPE_REGISTER(Placeholder);
         MODEL_OP_TYPE_REGISTER(Transpose);
         MODEL_OP_TYPE_REGISTER(SendPacket);
         MODEL_OP_TYPE_REGISTER(RecvPacket);

--- a/ark/model_buffer_manager.hpp
+++ b/ark/model_buffer_manager.hpp
@@ -8,7 +8,8 @@
 #include <unordered_map>
 
 namespace ark {
-// Manages externally allocated buffers not in the ARK memory space.
+// Manages externally allocated buffers (buffers corresponding to Tensors that
+// are the output of a `placeholder` operation) outside of ARK's memory space.
 class ModelBufferManager {
    public:
     static ModelBufferManager& get_instance() {
@@ -16,11 +17,11 @@ class ModelBufferManager {
         return instance;
     }
 
-    void register_buffer(size_t id, void* data, size_t size) {
+    void register_buffer(const size_t id, void* const data, const size_t size) {
         buffers_[id] = std::make_tuple(data, size);
     }
 
-    void* get_buffer(size_t id) {
+    void* get_buffer(const size_t id) const {
         auto it = buffers_.find(id);
         if (it != buffers_.end()) {
             return std::get<0>(it->second);
@@ -28,12 +29,16 @@ class ModelBufferManager {
         return nullptr;
     }
 
-    size_t get_buffer_size(size_t id) {
+    size_t get_buffer_size(const size_t id) const {
         auto it = buffers_.find(id);
         if (it != buffers_.end()) {
             return std::get<1>(it->second);
         }
         return 0;
+    }
+
+    bool is_external(const size_t id) const {
+        return buffers_.find(id) != buffers_.end();
     }
 
     const std::unordered_map<size_t, std::tuple<void*, size_t>>& get_buffers()

--- a/ark/ops/ops_placeholder.cpp
+++ b/ark/ops/ops_placeholder.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "ops_placeholder.hpp"
+
+#include "logging.hpp"
+#include "model_buffer_manager.hpp"
+#include "ops_common.hpp"
+
+namespace ark {
+
+ModelOpPlaceholder::ModelOpPlaceholder(ModelBufferRef buffer, const Dims &shape,
+                                       ModelDataType data_type,
+                                       const Dims &strides, const Dims &offsets,
+                                       const Dims &padded_shape,
+                                       void *external_data)
+    : ModelOp("Placeholder", true) {
+    if (!buffer) {
+        buffer = std::make_shared<ModelBuffer>();
+    }
+    const std::vector<DimType> &shape_vec = shape.vector();
+    DataType dtype = ModelDataType(data_type);
+
+    size_t external_data_size =
+        std::accumulate(shape_vec.begin(), shape_vec.end(), 1,
+                        std::multiplies<int64_t>()) *
+        dtype.bytes();
+
+    ModelBufferManager::get_instance().register_buffer(
+        buffer->id(), external_data, external_data_size);
+
+    ModelTensorRef tensor = std::make_shared<ModelTensor>(
+        data_type, buffer, shape, strides, offsets, padded_shape);
+
+    result_tensors_.emplace_back(tensor);
+
+    verify();
+}
+
+Tensor Model::placeholder(const Dims &shape, const DataType &data_type,
+                          const Dims &strides, const Dims &offsets,
+                          const Dims &padded_shape, int rank,
+                          const std::string &name, void *external_data) {
+    if (rank != -1) {
+        if (rank == this->rank()) {
+            rank = -1;
+        } else if (rank < 0 || rank >= this->world_size()) {
+            ERR(ModelError, "Invalid rank %d", rank);
+        }
+    }
+    return impl_
+        ->create_op<ModelOpPlaceholder>(
+            name, std::make_shared<ModelBuffer>(rank), shape, data_type.ref(),
+            strides, offsets, padded_shape, external_data)
+        ->result_tensors()[0];
+}
+}  // namespace ark

--- a/ark/ops/ops_placeholder.hpp
+++ b/ark/ops/ops_placeholder.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#ifndef ARK_OPS_PLACEHOLDER_HPP_
+#define ARK_OPS_PLACEHOLDER_HPP_
+
+#include "ark/model.hpp"
+#include "model/model_op.hpp"
+
+namespace ark {
+
+class ModelOpPlaceholder : public ModelOp {
+   public:
+    ModelOpPlaceholder() = default;
+    ModelOpPlaceholder(ModelBufferRef buffer, const Dims &shape,
+                       ModelDataType data_type, const Dims &strides,
+                       const Dims &offsets, const Dims &padded_shape,
+                       void *external_data = nullptr);
+};
+
+}  // namespace ark
+
+#endif  // ARK_OPS_PLACEHOLDER_HPP_

--- a/ark/ops/ops_placeholder_test.cpp
+++ b/ark/ops/ops_placeholder_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <cstring>
+#include <numeric>
+
+#include "ark/executor.hpp"
+#include "gpu/gpu.hpp"
+#include "logging.hpp"
+#include "model/model_node.hpp"
+#include "model/model_op.hpp"
+#include "ops_test_common.hpp"
+
+ark::unittest::State test_ops_placeholder_value_contiguous() {
+    ark::Model model;
+    ark::Dims shape{10, 1};
+
+    // Allocate GPU memory for the external buffer
+    float *d_ext_buffer = nullptr;
+    ark::gpuMalloc(&d_ext_buffer, shape.nelems() * sizeof(float));
+
+    // Initialize GPU Memory
+    std::vector<float> h_ext_buffer(shape.nelems());
+    std::iota(h_ext_buffer.begin(), h_ext_buffer.end(), 1.0f);
+    ark::gpuMemcpy(d_ext_buffer, h_ext_buffer.data(),
+                   shape.nelems() * sizeof(float), ark::gpuMemcpyHostToDevice);
+
+    // Associate the initialzied device buffer with a tensor produced from a
+    // placeholder operation
+    auto tns =
+        model.placeholder(shape, ark::FP32, {}, {}, {}, -1, "", d_ext_buffer);
+
+    // Copy tensor data from GPU to CPU
+    std::vector<float> res(shape.nelems(), 0.0f);
+    ark::gpuMemcpy(res.data(), d_ext_buffer, shape.nelems() * sizeof(float),
+                   ark::gpuMemcpyDeviceToHost);
+
+    for (auto i = 0; i < shape.nelems(); ++i) {
+        UNITTEST_EQ(res[i], i + 1);
+    }
+
+    cudaFree(d_ext_buffer);
+
+    return ark::unittest::SUCCESS;
+}
+
+int main() {
+    ark::init();
+    UNITTEST(test_ops_placeholder_value_contiguous);
+    return ark::unittest::SUCCESS;
+}


### PR DESCRIPTION
- Separates externally allocated buffers from `ModelBuffer` by having `ModelBufferManager` manage them instead.
- Adds the `placeholder` operation. `placeholder` is a virtual operation that produces a `Tensor` with the added feature of providing a data pointer (which can be null to support delayed binding) to an external buffer.