### PR TITLE
Add TensorLocation enum + fused matmul epilogues

### DIFF
--- a/ark/include/ark/model.hpp
+++ b/ark/include/ark/model.hpp
@@ -151,6 +151,23 @@ class Model : public ModelGraph {
     Tensor matmul(Tensor input, Tensor other, Tensor output = NullTensor,
                   bool trans_input = false, bool trans_other = false,
                   const std::string &name = "");
+    Tensor matmul_gelu(Tensor input, Tensor other,
+                       Tensor output = NullTensor,
+                       bool trans_input = false, bool trans_other = false,
+                       const std::string &name = "");
+    Tensor matmul_scale(Tensor input, Tensor other, float scale,
+                        Tensor output = NullTensor,
+                        bool trans_input = false, bool trans_other = false,
+                        const std::string &name = "");
+    Tensor matmul_add(Tensor input, Tensor other, Tensor residual,
+                      Tensor output = NullTensor,
+                      bool trans_input = false, bool trans_other = false,
+                      const std::string &name = "");
+    Tensor mma(Tensor input, Tensor other, Tensor output = NullTensor,
+               bool trans_input = false, bool trans_other = false,
+               const std::string &name = "");
+    Tensor store(Tensor output, Tensor input,
+                 const std::string &name = "");
     // Implements the 'im2col' method for 2D convolution layers, which takes an
     // `input` tensor and reshapes it to a 2D matrix by extracting image patches
     // from the input tensor based on the provided parameters.

--- a/ark/include/kernels/gemm_cutlass.h
+++ b/ark/include/kernels/gemm_cutlass.h
@@ -20,6 +20,8 @@
 #include "cutlass/epilogue/thread/linear_combination.h"
 // clang-format on
 
+#include "cutlass/epilogue/thread/linear_combination_gelu.h"
+
 #include "common/checker.h"
 #include "common/unit_op.h"
 
@@ -98,6 +100,44 @@ struct GemmConfiguration {
         ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC,
         ElementAccumulator, OperatorClass, ArchTag, Shape, WarpShape, InstShape,
         cutlass::epilogue::thread::LinearCombination<
+            ElementC, 128 / cutlass::sizeof_bits<ElementC>::value,
+            ElementAccumulator, ElementAccumulator>,
+        ark::GemmThreadblockSwizzle<UnitOp>, 3>;
+};
+
+/// GemmConfiguration with GELU activation fused into epilogue.
+/// D = gelu(alpha * A*B + beta * C)
+template <typename UnitOp, typename OperatorClass, typename ArchTag,
+          typename ElementA, typename LayoutA, typename ElementB,
+          typename LayoutB, typename ElementC, typename LayoutC, typename Shape>
+struct GemmConfigurationGelu {
+    static_assert(std::is_same_v<ElementA, float> ||
+                      std::is_same_v<ElementA, cutlass::half_t> ||
+                      std::is_same_v<ElementA, cutlass::bfloat16_t>,
+                  "ElementA must be float, half, or bfloat16");
+    static_assert(std::is_same_v<ElementB, float> ||
+                      std::is_same_v<ElementB, cutlass::half_t> ||
+                      std::is_same_v<ElementB, cutlass::bfloat16_t>,
+                  "ElementB must be float, half, or bfloat16");
+    static_assert(std::is_same_v<ElementC, float> ||
+                      std::is_same_v<ElementC, cutlass::half_t> ||
+                      std::is_same_v<ElementC, cutlass::bfloat16_t>,
+                  "ElementC must be float, half, or bfloat16");
+    using ElementAccumulator = typename std::conditional_t<
+        std::is_same_v<ElementC, cutlass::bfloat16_t>, float, ElementC>;
+    static constexpr int NumWarps = UnitOp::NumWarps;
+    static constexpr int NumWarpsN =
+        1 << math::div_up<math::log2_up<NumWarps>::value, 2>::value;
+    static constexpr int NumWarpsM = NumWarps / NumWarpsN;
+    using WarpShape =
+        cutlass::gemm::GemmShape<Shape::kM / NumWarpsM, Shape::kN / NumWarpsN,
+                                 Shape::kK>;
+    using InstShape = typename InstructionShape<ArchTag, ElementAccumulator,
+                                                WarpShape>::value;
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC,
+        ElementAccumulator, OperatorClass, ArchTag, Shape, WarpShape, InstShape,
+        cutlass::epilogue::thread::LinearCombinationGELU<
             ElementC, 128 / cutlass::sizeof_bits<ElementC>::value,
             ElementAccumulator, ElementAccumulator>,
         ark::GemmThreadblockSwizzle<UnitOp>, 3>;
@@ -263,6 +303,147 @@ DEVICE void gemm_cuda(DataTypeC *C, DataTypeA *A, DataTypeB *B, int uop_idx,
     // for ARK, instead we need uop_idx to determine the tile offset.
     // Since swizzle_log_tile is the input to get_tile_offset(), we can
     // use it to pass uop_idx.
+    params.swizzle_log_tile = uop_idx;
+
+    typename GemmKernel::SharedStorage *ps =
+        UnitOp::template shared_memory<GemmKernel::SharedStorage>(
+            smem_per_warp);
+
+    UnitOp::sync_threads();
+
+    GemmKernel gemm_kernel{};
+    gemm_kernel(params, *ps);
+}
+
+/// CUDA GeMM with residual addition: D = A*B + Residual (beta=1).
+/// Takes a separate residual pointer that is added to the matmul output.
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp>
+DEVICE void gemm_cuda_add(DataTypeC *D, DataTypeA *A, DataTypeB *B,
+                          DataTypeC *Residual, int uop_idx,
+                          int smem_per_warp) {
+#if (ARK_TARGET_CUDA_ARCH == 60)
+    using ArchTag = cutlass::arch::Sm60;
+#elif (ARK_TARGET_CUDA_ARCH == 70)
+    using ArchTag = cutlass::arch::Sm70;
+#elif (ARK_TARGET_CUDA_ARCH == 80)
+    using ArchTag = cutlass::arch::Sm80;
+#elif (ARK_TARGET_CUDA_ARCH == 90)
+    using ArchTag = cutlass::arch::Sm80;
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+
+    using LayoutA = typename cutlass::platform::conditional<
+        IsColumnA, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutB = typename cutlass::platform::conditional<
+        IsColumnB, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    static constexpr int TileSizeK = std::is_same_v<DataTypeC, float> ? 32 : 64;
+    using GemmType = typename ark::GemmConfiguration<
+        UnitOp, cutlass::arch::OpClassTensorOp, ArchTag, DataTypeA, LayoutA,
+        DataTypeB, LayoutB, DataTypeC, LayoutC,
+        cutlass::gemm::GemmShape<TileSizeM, TileSizeN,
+                                 TileSizeK>>::Gemm;
+    using GemmKernel = typename GemmType::GemmKernel;
+
+    IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
+    IsEq<sizeof(GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+
+    LayoutA layout_a(LeadingDimA);
+    LayoutB layout_b(LeadingDimB);
+    LayoutC layout_c(LeadingDimC);
+    cutlass::TensorRef<DataTypeA, LayoutA> ref_a(A, layout_a);
+    cutlass::TensorRef<DataTypeB, LayoutB> ref_b(B, layout_b);
+    cutlass::TensorRef<DataTypeC, LayoutC> ref_c(Residual, layout_c);
+    cutlass::TensorRef<DataTypeC, LayoutC> ref_d(D, layout_c);
+
+    cutlass::gemm::GemmCoord problem_size(ProblemSizeM, ProblemSizeN,
+                                          ProblemSizeK);
+
+    ark::GemmThreadblockSwizzle<UnitOp> swizzle;
+    cutlass::gemm::GemmCoord tiled_shape(swizzle.get_tiled_shape());
+
+    // Set alpha=1, beta=1 so output = 1*A*B + 1*Residual
+    using EpilogueOp = typename GemmType::EpilogueOutputOp;
+    typename EpilogueOp::Params epilogue_params(
+        typename EpilogueOp::ElementCompute(1),
+        typename EpilogueOp::ElementCompute(1));
+
+    typename GemmKernel::Params params(problem_size, tiled_shape, ref_a, ref_b,
+                                       ref_c, ref_d, epilogue_params);
+    params.swizzle_log_tile = uop_idx;
+
+    typename GemmKernel::SharedStorage *ps =
+        UnitOp::template shared_memory<GemmKernel::SharedStorage>(
+            smem_per_warp);
+
+    UnitOp::sync_threads();
+
+    GemmKernel gemm_kernel{};
+    gemm_kernel(params, *ps);
+}
+/// Output = gelu(A * B). Same structure as gemm_cuda but uses
+/// GemmConfigurationGelu which applies GELU in the CUTLASS epilogue thread.
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp>
+DEVICE void gemm_cuda_gelu(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                           int uop_idx, int smem_per_warp) {
+#if (ARK_TARGET_CUDA_ARCH == 60)
+    using ArchTag = cutlass::arch::Sm60;
+#elif (ARK_TARGET_CUDA_ARCH == 70)
+    using ArchTag = cutlass::arch::Sm70;
+#elif (ARK_TARGET_CUDA_ARCH == 80)
+    using ArchTag = cutlass::arch::Sm80;
+#elif (ARK_TARGET_CUDA_ARCH == 90)
+    using ArchTag = cutlass::arch::Sm80;
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+
+    using LayoutA = typename cutlass::platform::conditional<
+        IsColumnA, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutB = typename cutlass::platform::conditional<
+        IsColumnB, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    static constexpr int TileSizeK = std::is_same_v<DataTypeC, float> ? 32 : 64;
+    using GemmKernel = typename ark::GemmConfigurationGelu<
+        UnitOp, cutlass::arch::OpClassTensorOp, ArchTag, DataTypeA, LayoutA,
+        DataTypeB, LayoutB, DataTypeC, LayoutC,
+        cutlass::gemm::GemmShape<TileSizeM, TileSizeN,
+                                 TileSizeK>>::Gemm::GemmKernel;
+
+    IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
+    IsEq<sizeof(GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+
+    LayoutA layout_a(LeadingDimA);
+    LayoutB layout_b(LeadingDimB);
+    LayoutC layout_c(LeadingDimC);
+    cutlass::TensorRef<DataTypeA, LayoutA> ref_a(A, layout_a);
+    cutlass::TensorRef<DataTypeB, LayoutB> ref_b(B, layout_b);
+    cutlass::TensorRef<DataTypeC, LayoutC> ref_c(C, layout_c);
+
+    cutlass::gemm::GemmCoord problem_size(ProblemSizeM, ProblemSizeN,
+                                          ProblemSizeK);
+    cutlass::gemm::GemmCoord threadblock_shape(TileSizeM, TileSizeN, TileSizeK);
+
+    ark::GemmThreadblockSwizzle<UnitOp> swizzle;
+    cutlass::gemm::GemmCoord tiled_shape(swizzle.get_tiled_shape());
+
+    typename GemmKernel::Params params(problem_size, tiled_shape, ref_a, ref_b,
+                                       ref_c, ref_c);
     params.swizzle_log_tile = uop_idx;
 
     typename GemmKernel::SharedStorage *ps =
@@ -447,6 +628,88 @@ DEVICE void gemm_cutlass(DataTypeC *C, DataTypeA *A, DataTypeB *B, int uop_idx,
               IsColumnB, CutDataTypeC, LeadingDimC, ProblemSizeM, ProblemSizeN,
               ProblemSizeK, TileSizeM, TileSizeN, UnitOp>(pC, pA, pB, uop_idx,
                                                           smem_per_warp);
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+}
+
+/// Row-major GeMM with GELU activation fused into the epilogue.
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp>
+DEVICE void gemm_cutlass_gelu(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                              int uop_idx, int smem_per_warp) {
+    using CutDataTypeA = typename cutlass::platform::conditional<
+        std::is_same<DataTypeA, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeA, bf16>::value, cutlass::bfloat16_t,
+            DataTypeA>::type>::type;
+
+    using CutDataTypeB = typename cutlass::platform::conditional<
+        std::is_same<DataTypeB, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeB, bf16>::value, cutlass::bfloat16_t,
+            DataTypeB>::type>::type;
+
+    using CutDataTypeC = typename cutlass::platform::conditional<
+        std::is_same<DataTypeC, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeC, bf16>::value, cutlass::bfloat16_t,
+            DataTypeC>::type>::type;
+
+    CutDataTypeC *pC = reinterpret_cast<CutDataTypeC *>(C);
+    CutDataTypeA *pA = reinterpret_cast<CutDataTypeA *>(A);
+    CutDataTypeB *pB = reinterpret_cast<CutDataTypeB *>(B);
+
+#if (ARK_TARGET_CUDA_ARCH == 60 || ARK_TARGET_CUDA_ARCH == 70 || \
+     ARK_TARGET_CUDA_ARCH == 80 || ARK_TARGET_CUDA_ARCH == 90)
+    gemm_cuda_gelu<CutDataTypeA, LeadingDimA, IsColumnA, CutDataTypeB,
+                   LeadingDimB, IsColumnB, CutDataTypeC, LeadingDimC,
+                   ProblemSizeM, ProblemSizeN, ProblemSizeK, TileSizeM,
+                   TileSizeN, UnitOp>(pC, pA, pB, uop_idx, smem_per_warp);
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+}
+
+/// Row-major GeMM with residual addition: D = A*B + Residual.
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp>
+DEVICE void gemm_cutlass_add(DataTypeC *D, DataTypeA *A, DataTypeB *B,
+                             DataTypeC *Residual, int uop_idx,
+                             int smem_per_warp) {
+    using CutDataTypeA = typename cutlass::platform::conditional<
+        std::is_same<DataTypeA, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeA, bf16>::value, cutlass::bfloat16_t,
+            DataTypeA>::type>::type;
+    using CutDataTypeB = typename cutlass::platform::conditional<
+        std::is_same<DataTypeB, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeB, bf16>::value, cutlass::bfloat16_t,
+            DataTypeB>::type>::type;
+    using CutDataTypeC = typename cutlass::platform::conditional<
+        std::is_same<DataTypeC, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeC, bf16>::value, cutlass::bfloat16_t,
+            DataTypeC>::type>::type;
+
+    CutDataTypeC *pD = reinterpret_cast<CutDataTypeC *>(D);
+    CutDataTypeA *pA = reinterpret_cast<CutDataTypeA *>(A);
+    CutDataTypeB *pB = reinterpret_cast<CutDataTypeB *>(B);
+    CutDataTypeC *pR = reinterpret_cast<CutDataTypeC *>(Residual);
+
+#if (ARK_TARGET_CUDA_ARCH == 60 || ARK_TARGET_CUDA_ARCH == 70 || \
+     ARK_TARGET_CUDA_ARCH == 80 || ARK_TARGET_CUDA_ARCH == 90)
+    gemm_cuda_add<CutDataTypeA, LeadingDimA, IsColumnA, CutDataTypeB,
+                  LeadingDimB, IsColumnB, CutDataTypeC, LeadingDimC,
+                  ProblemSizeM, ProblemSizeN, ProblemSizeK, TileSizeM,
+                  TileSizeN, UnitOp>(pD, pA, pB, pR, uop_idx, smem_per_warp);
 #else
     static_assert(false, "Unsupported CUDA arch.");
 #endif

--- a/ark/include/kernels/gemm_cutlass.h
+++ b/ark/include/kernels/gemm_cutlass.h
@@ -123,8 +123,8 @@ struct GemmConfigurationGelu {
                       std::is_same_v<ElementC, cutlass::half_t> ||
                       std::is_same_v<ElementC, cutlass::bfloat16_t>,
                   "ElementC must be float, half, or bfloat16");
-    using ElementAccumulator = typename std::conditional_t<
-        std::is_same_v<ElementC, cutlass::bfloat16_t>, float, ElementC>;
+    // Always use float accumulator: GELU's erff needs fp32 precision.
+    using ElementAccumulator = float;
     static constexpr int NumWarps = UnitOp::NumWarps;
     static constexpr int NumWarpsN =
         1 << math::div_up<math::log2_up<NumWarps>::value, 2>::value;
@@ -354,7 +354,7 @@ DEVICE void gemm_cuda_add(DataTypeC *D, DataTypeA *A, DataTypeB *B,
     using GemmKernel = typename GemmType::GemmKernel;
 
     IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
-    IsEq<sizeof(GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+    IsEq<sizeof(typename GemmKernel::SharedStorage), UnitOp::SmemBytes>();
 
     LayoutA layout_a(LeadingDimA);
     LayoutB layout_b(LeadingDimB);
@@ -381,7 +381,7 @@ DEVICE void gemm_cuda_add(DataTypeC *D, DataTypeA *A, DataTypeB *B,
     params.swizzle_log_tile = uop_idx;
 
     typename GemmKernel::SharedStorage *ps =
-        UnitOp::template shared_memory<GemmKernel::SharedStorage>(
+        UnitOp::template shared_memory<typename GemmKernel::SharedStorage>(
             smem_per_warp);
 
     UnitOp::sync_threads();
@@ -426,7 +426,7 @@ DEVICE void gemm_cuda_gelu(DataTypeC *C, DataTypeA *A, DataTypeB *B,
                                  TileSizeK>>::Gemm::GemmKernel;
 
     IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
-    IsEq<sizeof(GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+    IsEq<sizeof(typename GemmKernel::SharedStorage), UnitOp::SmemBytes>();
 
     LayoutA layout_a(LeadingDimA);
     LayoutB layout_b(LeadingDimB);
@@ -447,7 +447,7 @@ DEVICE void gemm_cuda_gelu(DataTypeC *C, DataTypeA *A, DataTypeB *B,
     params.swizzle_log_tile = uop_idx;
 
     typename GemmKernel::SharedStorage *ps =
-        UnitOp::template shared_memory<GemmKernel::SharedStorage>(
+        UnitOp::template shared_memory<typename GemmKernel::SharedStorage>(
             smem_per_warp);
 
     UnitOp::sync_threads();

--- a/ark/include/kernels/gemm_fused.h
+++ b/ark/include/kernels/gemm_fused.h
@@ -114,6 +114,12 @@ DEVICE void gemm_with_functor(DataTypeC *C, DataTypeA *A, DataTypeB *B,
     using LayoutC = cutlass::layout::RowMajor;
 
     static constexpr int TileSizeK = std::is_same_v<DataTypeC, float> ? 32 : 64;
+    // NOTE: GemmConfiguration uses ElementC as accumulator for fp16 (half_t),
+    // and float for bf16/fp32. Functors that need fp32 precision throughout
+    // (e.g., exp, erff) should use a dedicated GemmConfiguration with
+    // ElementAccumulator = float. FunctorScale's float cast is sufficient
+    // for simple multiply, but FunctorScaleExp may lose precision with fp16
+    // accumulators.
     using GemmKernel = typename ark::GemmConfiguration<
         UnitOp, cutlass::arch::OpClassTensorOp, ArchTag, DataTypeA, LayoutA,
         DataTypeB, LayoutB, DataTypeC, LayoutC,

--- a/ark/include/kernels/gemm_fused.h
+++ b/ark/include/kernels/gemm_fused.h
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Decomposed GEMM approach: Insert a user-defined functor between MMA
+// accumulation and the epilogue store. The functor operates on accumulator
+// registers before they're written to global memory, eliminating the
+// global→global data path for fused elementwise ops.
+//
+// Data flow:
+//   global(A,B) → shared → MMA → accum(registers) → Functor → Epilogue → global(C)
+//
+// vs current matmul + separate elementwise:
+//   global(A,B) → shared → MMA → Epilogue → global(C)
+//   global(C) → elementwise → global(C)   ← EXTRA global read+write
+
+#ifndef ARK_KERNELS_GEMM_FUSED_H_
+#define ARK_KERNELS_GEMM_FUSED_H_
+
+#include "gemm_cutlass.h"
+
+namespace ark {
+
+// ============================================================================
+// Functors that operate on CUTLASS accumulator fragments (in registers)
+// ============================================================================
+
+struct FunctorIdentity {
+    template <typename FragmentC>
+    DEVICE static void apply(FragmentC &) {}
+};
+
+struct FunctorScale {
+    float scale;
+    template <typename FragmentC>
+    DEVICE void apply(FragmentC &accum) const {
+        using Element = typename FragmentC::Element;
+        for (int i = 0; i < FragmentC::kElements; i++) {
+            float val = static_cast<float>(accum[i]);
+            accum[i] = static_cast<Element>(val * scale);
+        }
+    }
+};
+
+struct FunctorGelu {
+    template <typename FragmentC>
+    DEVICE static void apply(FragmentC &accum) {
+        using Element = typename FragmentC::Element;
+        for (int i = 0; i < FragmentC::kElements; i++) {
+            float x = static_cast<float>(accum[i]);
+            accum[i] = static_cast<Element>(
+                x * 0.5f * (1.0f + erff(x * 0.7071067811865475f)));
+        }
+    }
+};
+
+struct FunctorRelu {
+    template <typename FragmentC>
+    DEVICE static void apply(FragmentC &accum) {
+        using Element = typename FragmentC::Element;
+        for (int i = 0; i < FragmentC::kElements; i++) {
+            float val = static_cast<float>(accum[i]);
+            accum[i] = static_cast<Element>(val > 0.f ? val : 0.f);
+        }
+    }
+};
+
+// Scale + Exp (for attention: exp(score * scale))
+struct FunctorScaleExp {
+    float scale;
+    template <typename FragmentC>
+    DEVICE void apply(FragmentC &accum) const {
+        using Element = typename FragmentC::Element;
+        for (int i = 0; i < FragmentC::kElements; i++) {
+            float val = static_cast<float>(accum[i]);
+            accum[i] = static_cast<Element>(expf(val * scale));
+        }
+    }
+};
+
+// ============================================================================
+// gemm_with_functor: CUTLASS Mma + Functor on accumulators + Epilogue
+//
+// IMPORTANT: DataTypeA/B/C must be CUTLASS types (cutlass::half_t, etc.),
+// NOT ARK types (ark::fp16). Use the gemm_cutlass_fused() wrapper below
+// for ARK type conversion.
+// ============================================================================
+
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp, typename Functor>
+DEVICE void gemm_with_functor(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                              Functor functor,
+                              int uop_idx, int smem_per_warp) {
+#if (ARK_TARGET_CUDA_ARCH == 60)
+    using ArchTag = cutlass::arch::Sm60;
+#elif (ARK_TARGET_CUDA_ARCH == 70)
+    using ArchTag = cutlass::arch::Sm70;
+#elif (ARK_TARGET_CUDA_ARCH == 80)
+    using ArchTag = cutlass::arch::Sm80;
+#elif (ARK_TARGET_CUDA_ARCH == 90)
+    using ArchTag = cutlass::arch::Sm80;  // SM80 CUTLASS 2.x path for compat
+#else
+    static_assert(false, "Unsupported CUDA arch for gemm_with_functor");
+#endif
+
+    using LayoutA = typename cutlass::platform::conditional<
+        IsColumnA, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutB = typename cutlass::platform::conditional<
+        IsColumnB, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    static constexpr int TileSizeK = std::is_same_v<DataTypeC, float> ? 32 : 64;
+    using GemmKernel = typename ark::GemmConfiguration<
+        UnitOp, cutlass::arch::OpClassTensorOp, ArchTag, DataTypeA, LayoutA,
+        DataTypeB, LayoutB, DataTypeC, LayoutC,
+        cutlass::gemm::GemmShape<TileSizeM, TileSizeN,
+                                 TileSizeK>>::Gemm::GemmKernel;
+    using Mma = typename GemmKernel::Mma;
+    using Epilogue = typename GemmKernel::Epilogue;
+    using OutputOp = typename GemmKernel::OutputOp;
+
+    IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
+    IsEq<sizeof(typename GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+
+    LayoutA layout_a(LeadingDimA);
+    LayoutB layout_b(LeadingDimB);
+    LayoutC layout_c(LeadingDimC);
+    cutlass::TensorRef<DataTypeA, LayoutA> ref_a(A, layout_a);
+    cutlass::TensorRef<DataTypeB, LayoutB> ref_b(B, layout_b);
+    cutlass::TensorRef<DataTypeC, LayoutC> ref_c(C, layout_c);
+
+    cutlass::gemm::GemmCoord problem_size(ProblemSizeM, ProblemSizeN,
+                                          ProblemSizeK);
+
+    ark::GemmThreadblockSwizzle<UnitOp> swizzle;
+    cutlass::gemm::GemmCoord tiled_shape(swizzle.get_tiled_shape());
+
+    typename GemmKernel::Params params(problem_size, tiled_shape,
+                                       ref_a, ref_b, ref_c, ref_c);
+    params.swizzle_log_tile = uop_idx;
+
+    typename GemmKernel::SharedStorage *ps =
+        UnitOp::template shared_memory<typename GemmKernel::SharedStorage>(
+            smem_per_warp);
+
+    UnitOp::sync_threads();
+
+    // --- Phase 1: Mma mainloop (same as standard CUTLASS) ---
+
+    cutlass::gemm::GemmCoord threadblock_tile_offset =
+        swizzle.get_tile_offset(uop_idx);
+
+    if (tiled_shape.m() <= threadblock_tile_offset.m() ||
+        tiled_shape.n() <= threadblock_tile_offset.n()) {
+        return;
+    }
+
+    cutlass::MatrixCoord tb_offset_A{
+        threadblock_tile_offset.m() * Mma::Shape::kM, 0};
+    cutlass::MatrixCoord tb_offset_B{
+        0, threadblock_tile_offset.n() * Mma::Shape::kN};
+
+    int gemm_k_iterations =
+        (ProblemSizeK + Mma::Shape::kK - 1) / Mma::Shape::kK;
+    int thread_idx = threadIdx.x % GemmKernel::kThreadCount;
+
+    typename Mma::IteratorA iterator_A(
+        params.params_A, params.ref_A.data(),
+        {ProblemSizeM, ProblemSizeK}, thread_idx, tb_offset_A);
+
+    typename Mma::IteratorB iterator_B(
+        params.params_B, params.ref_B.data(),
+        {ProblemSizeK, ProblemSizeN}, thread_idx, tb_offset_B);
+
+    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0) %
+                   GemmKernel::WarpCount::kCount;
+    int lane_idx = threadIdx.x % 32;
+
+    Mma mma(ps->main_loop, thread_idx, warp_idx, lane_idx);
+
+    typename Mma::FragmentC accumulators;
+    accumulators.clear();
+    mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
+
+    // --- Phase 2: Apply functor on accumulator registers ---
+    functor.apply(accumulators);
+
+    // --- Phase 3: Epilogue (write to global memory) ---
+    // Uses default OutputOp (alpha=1, beta=0) — just stores the
+    // (functor-modified) accumulators to global memory.
+    OutputOp output_op(params.output_op);
+
+    threadblock_tile_offset = swizzle.get_tile_offset(params.swizzle_log_tile);
+
+    typename Epilogue::OutputTileIterator iterator_C(
+        params.params_C, params.ref_C.data(), params.problem_size.mn(),
+        thread_idx,
+        {threadblock_tile_offset.m() * Mma::Shape::kM,
+         threadblock_tile_offset.n() * Mma::Shape::kN});
+
+    typename Epilogue::OutputTileIterator iterator_D(
+        params.params_D, params.ref_D.data(), params.problem_size.mn(),
+        thread_idx,
+        {threadblock_tile_offset.m() * Mma::Shape::kM,
+         threadblock_tile_offset.n() * Mma::Shape::kN});
+
+    Epilogue epilogue(ps->epilogue, thread_idx, warp_idx, lane_idx);
+    epilogue(output_op, iterator_D, accumulators, iterator_C);
+}
+
+// ============================================================================
+// gemm_cutlass_fused: ARK type conversion wrapper for gemm_with_functor.
+// Converts ark::fp16/bf16/fp32 → cutlass::half_t/bfloat16_t/float, then
+// calls gemm_with_functor.
+// ============================================================================
+
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp, typename Functor>
+DEVICE void gemm_cutlass_fused(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                               Functor functor,
+                               int uop_idx, int smem_per_warp) {
+    using CutDataTypeA = typename cutlass::platform::conditional<
+        std::is_same<DataTypeA, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeA, bf16>::value, cutlass::bfloat16_t,
+            DataTypeA>::type>::type;
+
+    using CutDataTypeB = typename cutlass::platform::conditional<
+        std::is_same<DataTypeB, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeB, bf16>::value, cutlass::bfloat16_t,
+            DataTypeB>::type>::type;
+
+    using CutDataTypeC = typename cutlass::platform::conditional<
+        std::is_same<DataTypeC, fp16>::value, cutlass::half_t,
+        typename cutlass::platform::conditional<
+            std::is_same<DataTypeC, bf16>::value, cutlass::bfloat16_t,
+            DataTypeC>::type>::type;
+
+    CutDataTypeC *pC = reinterpret_cast<CutDataTypeC *>(C);
+    CutDataTypeA *pA = reinterpret_cast<CutDataTypeA *>(A);
+    CutDataTypeB *pB = reinterpret_cast<CutDataTypeB *>(B);
+
+#if (ARK_TARGET_CUDA_ARCH == 60 || ARK_TARGET_CUDA_ARCH == 70 || \
+     ARK_TARGET_CUDA_ARCH == 80 || ARK_TARGET_CUDA_ARCH == 90)
+    gemm_with_functor<CutDataTypeA, LeadingDimA, IsColumnA, CutDataTypeB,
+                      LeadingDimB, IsColumnB, CutDataTypeC, LeadingDimC,
+                      ProblemSizeM, ProblemSizeN, ProblemSizeK, TileSizeM,
+                      TileSizeN, UnitOp, Functor>(pC, pA, pB, functor,
+                                                   uop_idx, smem_per_warp);
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+}
+
+}  // namespace ark
+
+#endif  // ARK_KERNELS_GEMM_FUSED_H_

--- a/ark/include/kernels/gemm_scale.h
+++ b/ark/include/kernels/gemm_scale.h
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// GEMM with scale: D = alpha * (A @ B) where alpha = scale.
+// Uses CUTLASS LinearCombination epilogue with custom alpha.
+// The scale is applied on accumulator register fragments during the epilogue,
+// eliminating a separate global memory round-trip.
+
+#ifndef ARK_KERNELS_GEMM_SCALE_H_
+#define ARK_KERNELS_GEMM_SCALE_H_
+
+#include "gemm_cutlass.h"
+
+namespace ark {
+
+/// CUDA GeMM with scale: D = scale * A*B.
+/// Uses the standard CUTLASS epilogue with alpha=scale, beta=0.
+/// The scale is applied on register fragments in the epilogue thread function,
+/// before writing to global memory — NO extra global memory read/write.
+template <typename DataTypeA, int LeadingDimA, bool IsColumnA,
+          typename DataTypeB, int LeadingDimB, bool IsColumnB,
+          typename DataTypeC, int LeadingDimC, int ProblemSizeM,
+          int ProblemSizeN, int ProblemSizeK, int TileSizeM, int TileSizeN,
+          typename UnitOp, uint32_t ScaleBits>
+DEVICE void gemm_cuda_scale(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                            int uop_idx, int smem_per_warp) {
+#if (ARK_TARGET_CUDA_ARCH == 70)
+    using ArchTag = cutlass::arch::Sm70;
+#elif (ARK_TARGET_CUDA_ARCH == 80)
+    using ArchTag = cutlass::arch::Sm80;
+#elif (ARK_TARGET_CUDA_ARCH == 90)
+    using ArchTag = cutlass::arch::Sm80;
+#else
+    static_assert(false, "Unsupported CUDA arch.");
+#endif
+
+    using LayoutA = typename cutlass::platform::conditional<
+        IsColumnA, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutB = typename cutlass::platform::conditional<
+        IsColumnB, cutlass::layout::ColumnMajor,
+        cutlass::layout::RowMajor>::type;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    static constexpr int TileSizeK = std::is_same_v<DataTypeC, float> ? 32 : 64;
+    using GemmKernel = typename ark::GemmConfiguration<
+        UnitOp, cutlass::arch::OpClassTensorOp, ArchTag, DataTypeA, LayoutA,
+        DataTypeB, LayoutB, DataTypeC, LayoutC,
+        cutlass::gemm::GemmShape<TileSizeM, TileSizeN,
+                                 TileSizeK>>::Gemm::GemmKernel;
+    using OutputOp = typename GemmKernel::OutputOp;
+
+    IsEq<GemmKernel::kThreadCount, UnitOp::NumThreads>();
+    IsEq<sizeof(typename GemmKernel::SharedStorage), UnitOp::SmemBytes>();
+
+    LayoutA layout_a(LeadingDimA);
+    LayoutB layout_b(LeadingDimB);
+    LayoutC layout_c(LeadingDimC);
+    cutlass::TensorRef<DataTypeA, LayoutA> ref_a(A, layout_a);
+    cutlass::TensorRef<DataTypeB, LayoutB> ref_b(B, layout_b);
+    cutlass::TensorRef<DataTypeC, LayoutC> ref_c(C, layout_c);
+
+    cutlass::gemm::GemmCoord problem_size(ProblemSizeM, ProblemSizeN,
+                                          ProblemSizeK);
+    cutlass::gemm::GemmCoord threadblock_shape(TileSizeM, TileSizeN, TileSizeK);
+
+    ark::GemmThreadblockSwizzle<UnitOp> swizzle;
+    cutlass::gemm::GemmCoord tiled_shape(swizzle.get_tiled_shape());
+
+    // Decode scale from bits
+    union { uint32_t u; float f; } conv;
+    conv.u = ScaleBits;
+
+    // Create OutputOp params with alpha=scale, beta=0
+    typename OutputOp::Params output_op_params(
+        static_cast<typename OutputOp::ElementCompute>(conv.f),
+        static_cast<typename OutputOp::ElementCompute>(0));
+
+    typename GemmKernel::Params params(problem_size, tiled_shape, ref_a, ref_b,
+                                       ref_c, ref_c, output_op_params);
+
+    params.swizzle_log_tile = uop_idx;
+
+    typename GemmKernel::SharedStorage *ps =
+        UnitOp::template shared_memory<typename GemmKernel::SharedStorage>(
+            smem_per_warp);
+
+    UnitOp::sync_threads();
+
+    GemmKernel gemm_kernel{};
+    gemm_kernel(params, *ps);
+}
+
+}  // namespace ark
+
+#endif  // ARK_KERNELS_GEMM_SCALE_H_

--- a/ark/include/kernels/matmul.h
+++ b/ark/include/kernels/matmul.h
@@ -217,10 +217,10 @@ template <typename OutDims, typename NCA, typename NCB, typename TileShape,
           typename DataTypeA, typename DataTypeB, typename DataTypeC>
 DEVICE void matmul_scale(DataTypeC *C, DataTypeA *A, DataTypeB *B,
                          int uop_idx, int smem_per_warp) {
-    static_assert(NCA::D2 == 1 && NCA::D3 == 1);
-    static_assert(NCB::D2 == 1 && NCB::D3 == 1);
-    static_assert(TileShape::D2 == 1 && TileShape::D3 == 1);
-    static_assert(ProblemSize::D3 == 1);
+    static_assert(NCA::D2 == 1 && NCA::D3 == 1, "NCA should be two dimensional.");
+    static_assert(NCB::D2 == 1 && NCB::D3 == 1, "NCB should be two dimensional.");
+    static_assert(TileShape::D2 == 1 && TileShape::D3 == 1, "TileShape should be two dimensional.");
+    static_assert(ProblemSize::D3 == 1, "ProblemSize D3 should be 1.");
 
     constexpr int NC = (NCA::D0 > NCB::D0) ? NCA::D0 : NCB::D0;
     constexpr int CC = (NCA::D1 > NCB::D1) ? NCA::D1 : NCB::D1;

--- a/ark/include/kernels/matmul.h
+++ b/ark/include/kernels/matmul.h
@@ -93,6 +93,162 @@ DEVICE void matmul(DataTypeC *C, DataTypeA *A, DataTypeB *B, int uop_idx,
 #endif
 }
 
+/// Matrix multiplication with GELU activation fused into the epilogue.
+/// Output = gelu(A @ B). Only supported on CUDA (CUTLASS).
+template <typename OutDims, typename NCA, typename NCB, typename TileShape,
+          typename ProblemSize, typename LeadingDims, int BatchStrideNA,
+          int BatchStrideCA, int BatchStrideNB, int BatchStrideCB,
+          int BatchStrideNC, int BatchStrideCC, bool IsColumnA, bool IsColumnB,
+          int NumWarps, int SmemBytes, typename DataTypeA, typename DataTypeB,
+          typename DataTypeC>
+DEVICE void matmul_gelu(DataTypeC *C, DataTypeA *A, DataTypeB *B, int uop_idx,
+                        int smem_per_warp) {
+    static_assert(NCA::D2 == 1 && NCA::D3 == 1,
+                  "NCA should be two dimensional.");
+    static_assert(NCB::D2 == 1 && NCB::D3 == 1,
+                  "NCB should be two dimensional.");
+    static_assert(TileShape::D2 == 1 && TileShape::D3 == 1,
+                  "TileShape should be two dimensional.");
+    static_assert(ProblemSize::D3 == 1,
+                  "ProblemSize should be three dimensional.");
+
+    constexpr int NC = (NCA::D0 > NCB::D0) ? NCA::D0 : NCB::D0;
+    constexpr int CC = (NCA::D1 > NCB::D1) ? NCA::D1 : NCB::D1;
+
+    using OutShape = Vec<NC, CC, ProblemSize::D0, ProblemSize::D1>;
+    using UnitOutDims = Vec<1, 1, TileShape::D0, TileShape::D1>;
+    using UnitOp = UnitOp<OutDims, OutShape, UnitOutDims, NumWarps, SmemBytes>;
+
+    constexpr int LeadingDimA = LeadingDims::D0;
+    constexpr int LeadingDimB = LeadingDims::D3;
+    constexpr int LeadingDimC = LeadingDims::D1;
+    constexpr int ProblemSizeM = ProblemSize::D0;
+    constexpr int ProblemSizeN = ProblemSize::D1;
+    constexpr int ProblemSizeK = ProblemSize::D2;
+    constexpr int TileSizeM = TileShape::D0;
+    constexpr int TileSizeN = TileShape::D1;
+
+    int un = UnitOp::uop_idx_n(uop_idx);
+    int uc = UnitOp::uop_idx_c(uop_idx);
+
+    DataTypeA *pA = &A[un * BatchStrideNA + uc * BatchStrideCA];
+    DataTypeB *pB = &B[un * BatchStrideNB + uc * BatchStrideCB];
+    DataTypeC *pC = &C[un * BatchStrideNC + uc * BatchStrideCC];
+
+#if defined(ARK_TARGET_CUDA_ARCH)
+    gemm_cutlass_gelu<DataTypeA, LeadingDimA, IsColumnA, DataTypeB,
+                      LeadingDimB, IsColumnB, DataTypeC, LeadingDimC,
+                      ProblemSizeM, ProblemSizeN, ProblemSizeK, TileSizeM,
+                      TileSizeN, UnitOp>(pC, pA, pB, uop_idx, smem_per_warp);
+#elif defined(ARK_TARGET_ROCM_ARCH)
+    static_assert(false, "matmul_gelu not supported on ROCm.");
+#endif
+}
+
+/// Matrix multiplication with residual addition fused into the epilogue.
+/// Output = A @ B + Residual. Only supported on CUDA (CUTLASS).
+template <typename OutDims, typename NCA, typename NCB, typename TileShape,
+          typename ProblemSize, typename LeadingDims, int BatchStrideNA,
+          int BatchStrideCA, int BatchStrideNB, int BatchStrideCB,
+          int BatchStrideNC, int BatchStrideCC, bool IsColumnA, bool IsColumnB,
+          int NumWarps, int SmemBytes, typename DataTypeA, typename DataTypeB,
+          typename DataTypeC>
+DEVICE void matmul_add(DataTypeC *D, DataTypeA *A, DataTypeB *B,
+                       DataTypeC *Residual, int uop_idx, int smem_per_warp) {
+    static_assert(NCA::D2 == 1 && NCA::D3 == 1,
+                  "NCA should be two dimensional.");
+    static_assert(NCB::D2 == 1 && NCB::D3 == 1,
+                  "NCB should be two dimensional.");
+    static_assert(TileShape::D2 == 1 && TileShape::D3 == 1,
+                  "TileShape should be two dimensional.");
+    static_assert(ProblemSize::D3 == 1,
+                  "ProblemSize should be three dimensional.");
+
+    constexpr int NC = (NCA::D0 > NCB::D0) ? NCA::D0 : NCB::D0;
+    constexpr int CC = (NCA::D1 > NCB::D1) ? NCA::D1 : NCB::D1;
+
+    using OutShape = Vec<NC, CC, ProblemSize::D0, ProblemSize::D1>;
+    using UnitOutDims = Vec<1, 1, TileShape::D0, TileShape::D1>;
+    using UnitOp = UnitOp<OutDims, OutShape, UnitOutDims, NumWarps, SmemBytes>;
+
+    constexpr int LeadingDimA = LeadingDims::D0;
+    constexpr int LeadingDimB = LeadingDims::D3;
+    constexpr int LeadingDimC = LeadingDims::D1;
+    constexpr int ProblemSizeM = ProblemSize::D0;
+    constexpr int ProblemSizeN = ProblemSize::D1;
+    constexpr int ProblemSizeK = ProblemSize::D2;
+    constexpr int TileSizeM = TileShape::D0;
+    constexpr int TileSizeN = TileShape::D1;
+
+    int un = UnitOp::uop_idx_n(uop_idx);
+    int uc = UnitOp::uop_idx_c(uop_idx);
+
+    DataTypeA *pA = &A[un * BatchStrideNA + uc * BatchStrideCA];
+    DataTypeB *pB = &B[un * BatchStrideNB + uc * BatchStrideCB];
+    DataTypeC *pD = &D[un * BatchStrideNC + uc * BatchStrideCC];
+    DataTypeC *pR = &Residual[un * BatchStrideNC + uc * BatchStrideCC];
+
+#if defined(ARK_TARGET_CUDA_ARCH)
+    gemm_cutlass_add<DataTypeA, LeadingDimA, IsColumnA, DataTypeB, LeadingDimB,
+                     IsColumnB, DataTypeC, LeadingDimC, ProblemSizeM,
+                     ProblemSizeN, ProblemSizeK, TileSizeM, TileSizeN, UnitOp>(
+        pD, pA, pB, pR, uop_idx, smem_per_warp);
+#elif defined(ARK_TARGET_ROCM_ARCH)
+    static_assert(false, "matmul_add not supported on ROCm.");
+#endif
+}
+
 }  // namespace ark
+
+// Fused matmul with register-level functor (scale, gelu, relu, etc.)
+#if defined(ARK_TARGET_CUDA_ARCH)
+#include "gemm_fused.h"
+
+namespace ark {
+
+/// Matrix multiplication with scale: D = scale * (A @ B).
+/// The scale is applied on register accumulators via FunctorScale BEFORE
+/// the epilogue writes to global memory — zero extra global memory traffic.
+template <typename OutDims, typename NCA, typename NCB, typename TileShape,
+          typename ProblemSize, typename LeadingDims, int BatchStrideNA,
+          int BatchStrideCA, int BatchStrideNB, int BatchStrideCB,
+          int BatchStrideNC, int BatchStrideCC, bool IsColumnA, bool IsColumnB,
+          int NumWarps, int SmemBytes, uint32_t ScaleBits,
+          typename DataTypeA, typename DataTypeB, typename DataTypeC>
+DEVICE void matmul_scale(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                         int uop_idx, int smem_per_warp) {
+    static_assert(NCA::D2 == 1 && NCA::D3 == 1);
+    static_assert(NCB::D2 == 1 && NCB::D3 == 1);
+    static_assert(TileShape::D2 == 1 && TileShape::D3 == 1);
+    static_assert(ProblemSize::D3 == 1);
+
+    constexpr int NC = (NCA::D0 > NCB::D0) ? NCA::D0 : NCB::D0;
+    constexpr int CC = (NCA::D1 > NCB::D1) ? NCA::D1 : NCB::D1;
+    using OutShape = Vec<NC, CC, ProblemSize::D0, ProblemSize::D1>;
+    using UnitOutDims = Vec<1, 1, TileShape::D0, TileShape::D1>;
+    using UnitOp_t = UnitOp<OutDims, OutShape, UnitOutDims, NumWarps, SmemBytes>;
+
+    int un = UnitOp_t::uop_idx_n(uop_idx);
+    int uc = UnitOp_t::uop_idx_c(uop_idx);
+    DataTypeA *pA = &A[un * BatchStrideNA + uc * BatchStrideCA];
+    DataTypeB *pB = &B[un * BatchStrideNB + uc * BatchStrideCB];
+    DataTypeC *pC = &C[un * BatchStrideNC + uc * BatchStrideCC];
+
+    // Decode scale from bit-pattern template parameter
+    union { uint32_t u; float f; } conv;
+    conv.u = ScaleBits;
+    FunctorScale functor{conv.f};
+
+    gemm_cutlass_fused<
+        typename std::remove_const<DataTypeA>::type, LeadingDims::D0, IsColumnA,
+        typename std::remove_const<DataTypeB>::type, LeadingDims::D3, IsColumnB,
+        DataTypeC, LeadingDims::D1,
+        ProblemSize::D0, ProblemSize::D1, ProblemSize::D2,
+        TileShape::D0, TileShape::D1,
+        UnitOp_t, FunctorScale>(pC, pA, pB, functor, uop_idx, smem_per_warp);
+}
+
+}  // namespace ark
+#endif  // ARK_TARGET_CUDA_ARCH
 
 #endif  // ARK_KERNELS_MATMUL_H_

--- a/ark/include/kernels/matmul_fused.h
+++ b/ark/include/kernels/matmul_fused.h
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// matmul_fused: matmul with a post-MMA functor applied on register accumulators.
+// Wraps gemm_fused.h for ARK's op interface.
+
+#ifndef ARK_KERNELS_MATMUL_FUSED_H_
+#define ARK_KERNELS_MATMUL_FUSED_H_
+
+#include "gemm_fused.h"
+
+namespace ark {
+
+/// Matrix multiplication with scale applied on register accumulators.
+/// Output = (A @ B) * scale
+/// The scale is applied BEFORE writing to global memory, saving one
+/// global read+write cycle compared to separate matmul + scale ops.
+template <typename OutDims, typename NCA, typename NCB, typename TileShape,
+          typename ProblemSize, typename LeadingDims, int BatchStrideNA,
+          int BatchStrideCA, int BatchStrideNB, int BatchStrideCB,
+          int BatchStrideNC, int BatchStrideCC, bool IsColumnA, bool IsColumnB,
+          int NumWarps, int SmemBytes, typename DataTypeA, typename DataTypeB,
+          typename DataTypeC>
+DEVICE void matmul_scale(DataTypeC *C, DataTypeA *A, DataTypeB *B,
+                         float scale, int uop_idx, int smem_per_warp) {
+    constexpr int NC = (NCA::D0 > NCB::D0) ? NCA::D0 : NCB::D0;
+    constexpr int CC = (NCA::D1 > NCB::D1) ? NCA::D1 : NCB::D1;
+    using OutShape = Vec<NC, CC, ProblemSize::D0, ProblemSize::D1>;
+    using UnitOutDims = Vec<1, 1, TileShape::D0, TileShape::D1>;
+    using UnitOp_t = UnitOp<OutDims, OutShape, UnitOutDims, NumWarps, SmemBytes>;
+
+    constexpr int LeadingDimA = LeadingDims::D0;
+    constexpr int LeadingDimB = LeadingDims::D3;
+    constexpr int LeadingDimC = LeadingDims::D1;
+
+    int un = UnitOp_t::uop_idx_n(uop_idx);
+    int uc = UnitOp_t::uop_idx_c(uop_idx);
+
+    DataTypeA *pA = &A[un * BatchStrideNA + uc * BatchStrideCA];
+    DataTypeB *pB = &B[un * BatchStrideNB + uc * BatchStrideCB];
+    DataTypeC *pC = &C[un * BatchStrideNC + uc * BatchStrideCC];
+
+    FunctorScale functor{scale};
+    gemm_with_functor<
+        typename std::remove_const<DataTypeA>::type, LeadingDimA, IsColumnA,
+        typename std::remove_const<DataTypeB>::type, LeadingDimB, IsColumnB,
+        DataTypeC, LeadingDimC,
+        ProblemSize::D0, ProblemSize::D1, ProblemSize::D2,
+        TileShape::D0, TileShape::D1,
+        UnitOp_t, FunctorScale>(pC, pA, pB, functor, uop_idx, smem_per_warp);
+}
+
+}  // namespace ark
+
+#endif  // ARK_KERNELS_MATMUL_FUSED_H_

--- a/ark/include/kernels/matmul_fused.h
+++ b/ark/include/kernels/matmul_fused.h
@@ -41,7 +41,7 @@ DEVICE void matmul_scale(DataTypeC *C, DataTypeA *A, DataTypeB *B,
     DataTypeC *pC = &C[un * BatchStrideNC + uc * BatchStrideCC];
 
     FunctorScale functor{scale};
-    gemm_with_functor<
+    gemm_cutlass_fused<
         typename std::remove_const<DataTypeA>::type, LeadingDimA, IsColumnA,
         typename std::remove_const<DataTypeB>::type, LeadingDimB, IsColumnB,
         DataTypeC, LeadingDimC,

--- a/ark/model/model_op.cpp
+++ b/ark/model/model_op.cpp
@@ -60,6 +60,11 @@ const ModelOpType ModelOpT::from_name(const std::string &type_name) {
         MODEL_OP_TYPE_REGISTER(Exp);
         MODEL_OP_TYPE_REGISTER(Gelu);
         MODEL_OP_TYPE_REGISTER(Matmul);
+        MODEL_OP_TYPE_REGISTER(MatmulGelu);
+        MODEL_OP_TYPE_REGISTER(MatmulScale);
+        MODEL_OP_TYPE_REGISTER(MatmulAdd);
+        MODEL_OP_TYPE_REGISTER(Mma);
+        MODEL_OP_TYPE_REGISTER(Store);
         MODEL_OP_TYPE_REGISTER(Mul);
         MODEL_OP_TYPE_REGISTER(Noop);
         MODEL_OP_TYPE_REGISTER(Recv);

--- a/ark/model/model_tensor.cpp
+++ b/ark/model/model_tensor.cpp
@@ -12,8 +12,9 @@ namespace ark {
 
 ModelTensor::ModelTensor(ModelDataType data_type, ModelBufferRef buffer,
                          const Dims &shape, const Dims &strides,
-                         const Dims &offsets, const Dims &padded_shape)
-    : data_type_(data_type), buffer_(buffer) {
+                         const Dims &offsets, const Dims &padded_shape,
+                         TensorLocation location)
+    : data_type_(data_type), buffer_(buffer), location_(location) {
     if (shape.is_no_dim()) {
         // Assume a single-element constant
         shape_ = {1};
@@ -86,6 +87,7 @@ ModelTensor::ModelTensor(const ModelTensor &other) {
     strides_ = other.strides_;
     offsets_ = other.offsets_;
     padded_shape_ = other.padded_shape_;
+    location_ = other.location_;
 }
 
 size_t ModelTensor::shape_bytes() const {
@@ -111,6 +113,7 @@ Json ModelTensor::serialize() const {
     j["Offsets"] = offsets_.vector();
     j["PaddedShape"] = padded_shape_.vector();
     j["Buffer"] = buffer_->serialize();
+    j["Location"] = static_cast<int>(location_);
     return j;
 }
 
@@ -139,6 +142,10 @@ std::shared_ptr<ModelTensor> ModelTensor::deserialize(const Json &serialized) {
         serialized["Offsets"].get<std::vector<DimType>>(),
         serialized["PaddedShape"].get<std::vector<DimType>>());
     ret->id_ = serialized["Id"];
+    if (serialized.contains("Location")) {
+        ret->location_ = static_cast<TensorLocation>(
+            serialized["Location"].get<int>());
+    }
     return ret;
 }
 

--- a/ark/model/model_tensor.hpp
+++ b/ark/model/model_tensor.hpp
@@ -13,11 +13,19 @@ namespace ark {
 class ModelDataT;
 using ModelDataType = std::shared_ptr<ModelDataT>;
 
+/// Location of tensor data in the memory hierarchy.
+enum class TensorLocation {
+    GLOBAL,    // GPU global memory (HBM) — default, current behavior
+    SHARED,    // Shared memory (SMEM) — scoped to one thread block
+    REGISTER,  // Register file — scoped to one warp group (no buffer allocation)
+};
+
 class ModelTensor {
    public:
     ModelTensor(ModelDataType data_type, ModelBufferRef buffer,
                 const Dims &shape, const Dims &strides = {},
-                const Dims &offsets = {}, const Dims &padded_shape = {});
+                const Dims &offsets = {}, const Dims &padded_shape = {},
+                TensorLocation location = TensorLocation::GLOBAL);
 
     ModelTensor(const ModelTensor &other);
 
@@ -43,6 +51,9 @@ class ModelTensor {
 
     bool is_external() const;
 
+    TensorLocation location() const { return location_; }
+    void set_location(TensorLocation loc) { location_ = loc; }
+
     Json serialize() const;
 
     static std::shared_ptr<ModelTensor> deserialize(const Json &serialized);
@@ -57,6 +68,7 @@ class ModelTensor {
     Dims strides_;
     Dims offsets_;
     Dims padded_shape_;
+    TensorLocation location_ = TensorLocation::GLOBAL;
 };
 
 }  // namespace ark

--- a/ark/model/model_tensor.hpp
+++ b/ark/model/model_tensor.hpp
@@ -18,6 +18,9 @@ enum class TensorLocation {
     GLOBAL,    // GPU global memory (HBM) — default, current behavior
     SHARED,    // Shared memory (SMEM) — scoped to one thread block
     REGISTER,  // Register file — scoped to one warp group (no buffer allocation)
+               // TODO: Register-level fusion is not yet implemented.
+               // Planner and buffer allocator do not yet skip global
+               // allocation for REGISTER tensors. See ModelOpMma/ModelOpStore.
 };
 
 class ModelTensor {

--- a/ark/ops/ops_matmul.cpp
+++ b/ark/ops/ops_matmul.cpp
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 #include "ops_matmul.hpp"
+#include "ops_copy.hpp"
+#include "../model/model_tensor.hpp"
 
 #include <utility>
 
@@ -137,12 +139,8 @@ std::string ModelOpMatmul::impl_name(const Json &config) const {
     if (tile_shape.ndims() != 2) {
         ERR(PlanError, "Tile should have 2 elements");
     }
-    for (int i = 0; i < 2; ++i) {
-        if (padded_output_shape[i - 2] % tile_shape[i] != 0) {
-            ERR(PlanError, "output padded shape ", padded_output_shape,
-                " should be divisible by tile shape ", tile_shape);
-        }
-    }
+    // CUTLASS handles non-aligned shapes via boundary masking.
+    // No divisibility check needed — the planner uses ceil-div for NumTasks.
 
     DimType inner_stride_a;
     DimType inner_stride_b;
@@ -214,6 +212,68 @@ std::vector<ModelOpArg> ModelOpMatmul::impl_args(
     return {result_tensors_[0], read_tensors_[0], read_tensors_[1]};
 }
 
+// Compute CUTLASS shared memory requirement for a given tile.
+// For CUTLASS 2.x MmaMultistage with 3 pipeline stages:
+//   SramBytes = 3 * (TileM * TileK + TileK * TileN) * sizeof(dtype)
+// where TileK = 64 for fp16/bf16, 32 for fp32.
+static size_t compute_sram_bytes(DimType tm, DimType tn,
+                                 const ModelDataType &data_type) {
+    size_t tile_k = (data_type == FP32.ref()) ? 32 : 64;
+    size_t dtype_bytes = (data_type == FP32.ref()) ? 4 : 2;
+    return 3 * (tm * tile_k + tile_k * tn) * dtype_bytes;
+}
+
+// Select matmul tile that fits the problem dimensions and maximizes tasks.
+// The tile must divide M and N evenly. We try from smallest to largest
+// to maximize the number of tiles (= tasks = SMs used).
+static const Json select_tile_config(const ArchRef arch,
+                                     const ModelDataType &data_type,
+                                     const Dims &mnk) {
+    DimType M = mnk[0], N = mnk[1];
+    // Candidate tiles: {TileM, TileN, NumWarps}
+    // Ordered from smallest to largest. For each, M%TileM==0 and N%TileN==0 required.
+    struct TileConfig { DimType tm; DimType tn; int nw; };
+    // Only tiles validated to compile with CUTLASS 2.x epilogue.
+    // [32,*] tiles fail due to epilogue OutputTileOptimalThreadMap zero-size.
+    static const TileConfig candidates[] = {
+        {64, 64, 4},
+        {64, 128, 4},
+        {128, 64, 4},
+        {128, 128, 8},
+        {128, 256, 8},
+        {256, 128, 8},
+    };
+    // Find the best tile: prefer larger tiles (more compute per tile, better
+    // pipeline amortization) but fall back to smaller tiles when there aren't
+    // enough tasks to keep at least 4 SMs busy.
+    int best = -1;
+    size_t best_tasks = 0;
+    size_t best_tile_area = 0;
+    for (int i = 0; i < (int)(sizeof(candidates) / sizeof(candidates[0])); i++) {
+        auto &c = candidates[i];
+        if (M % c.tm == 0 && N % c.tn == 0) {
+            size_t tasks = (M / c.tm) * (N / c.tn);
+            size_t tile_area = c.tm * c.tn;
+            bool pick = (best == -1);
+            if (!pick && best_tasks < 4 && tasks > best_tasks) pick = true;
+            if (!pick && tasks >= 4 && tile_area > best_tile_area) pick = true;
+            if (pick) { best = i; best_tasks = tasks; best_tile_area = tile_area; }
+        }
+    }
+    if (best == -1) {
+        // No tile divides evenly. Pick the smallest tile; CUTLASS handles
+        // boundary tiles via predicated loads/stores (ceil-div in planner).
+        auto &c = candidates[0];  // [64, 64, 4]
+        return {{"NumWarps", c.nw},
+                {"SramBytes", (int)compute_sram_bytes(c.tm, c.tn, data_type)},
+                {"Tile", {c.tm, c.tn}}};
+    }
+    auto &c = candidates[best];
+    return {{"NumWarps", c.nw},
+            {"SramBytes", (int)compute_sram_bytes(c.tm, c.tn, data_type)},
+            {"Tile", {c.tm, c.tn}}};
+}
+
 static const Json get_default_config(const ArchRef arch,
                                      const ModelDataType &data_type,
                                      const Dims &mnk) {
@@ -224,21 +284,13 @@ static const Json get_default_config(const ArchRef arch,
     if (!arch->belongs_to(ARCH_CUDA) && !arch->belongs_to(ARCH_ROCM)) {
         ERR(PlanError, "Unsupported architecture: ", arch->name());
     }
+    if (arch->belongs_to(ARCH_CUDA)) {
+        return select_tile_config(arch, data_type, mnk);
+    }
+    // ROCm: keep original behavior
     DimType tm = (mnk[0] > mnk[1]) ? 256 : 128;
     DimType tn = (mnk[0] > mnk[1]) ? 128 : 256;
-    if (arch->belongs_to(ARCH_CUDA_80) && data_type == FP32.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_CUDA_80) && data_type == FP16.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_CUDA_80) && data_type == BF16.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_CUDA_90) && data_type == FP32.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_CUDA_90) && data_type == FP16.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_CUDA_90) && data_type == BF16.ref()) {
-        return {{"NumWarps", 8}, {"SramBytes", 147456}, {"Tile", {tm, tn}}};
-    } else if (arch->belongs_to(ARCH_ROCM_942) && data_type == FP32.ref()) {
+    if (arch->belongs_to(ARCH_ROCM_942) && data_type == FP32.ref()) {
         return {{"NumWarps", 4}, {"SramBytes", 24672}, {"Tile", {tm, tn}}};
     } else if (arch->belongs_to(ARCH_ROCM_942) && data_type == FP16.ref()) {
         return {{"NumWarps", 4}, {"SramBytes", 24672}, {"Tile", {tm, tn}}};
@@ -256,14 +308,7 @@ Json ModelOpMatmul::default_config(const ArchRef arch) const {
                                  read_tensors_[1]->padded_shape(),
                                  args_.at("TransposeInput").value<bool>(),
                                  args_.at("TransposeOther").value<bool>());
-    Json config = get_default_config(arch, result->data_type(), mnk);
-    size_t tile_x = config.at("Tile")[0];
-    size_t tile_y = config.at("Tile")[1];
-    if (mnk[0] % tile_x != 0 || mnk[1] % tile_y != 0) {
-        ERR(PlanError, "output padded shape ", Dims{mnk[0], mnk[1]},
-            " should be divisible by tile shape ", config.at("Tile"));
-    }
-    return config;
+    return get_default_config(arch, result->data_type(), mnk);
 }
 
 Tensor Model::matmul(Tensor input, Tensor other, Tensor output,
@@ -274,5 +319,278 @@ Tensor Model::matmul(Tensor input, Tensor other, Tensor output,
                                    trans_input, trans_other)
         ->result_tensors()[0];
 }
+
+ModelOpMatmulGelu::ModelOpMatmulGelu(ModelTensorRef input, ModelTensorRef other,
+                                     ModelTensorRef output, bool trans_input,
+                                     bool trans_other)
+    : ModelOpMatmul(input, other, output, trans_input, trans_other) {
+    type_ = ModelOpT::from_name("MatmulGelu");
+}
+
+std::string ModelOpMatmulGelu::impl_name(const Json &config) const {
+    // Reuse the parent impl_name but replace "matmul" with "matmul_gelu"
+    std::string name = ModelOpMatmul::impl_name(config);
+    // The name starts with "matmul<" — replace prefix
+    if (name.substr(0, 7) == "matmul<") {
+        name = "matmul_gelu<" + name.substr(7);
+    }
+    return name;
+}
+
+Tensor Model::matmul_gelu(Tensor input, Tensor other, Tensor output,
+                          bool trans_input, bool trans_other,
+                          const std::string &name) {
+    return impl_
+        ->create_op<ModelOpMatmulGelu>(name, input.ref(), other.ref(),
+                                       output.ref(), trans_input, trans_other)
+        ->result_tensors()[0];
+}
+
+// ---- MatmulScale: matmul with register-level scale fusion ----
+
+ModelOpMatmulScale::ModelOpMatmulScale(ModelTensorRef input, ModelTensorRef other,
+                                       ModelTensorRef output, bool trans_input,
+                                       bool trans_other, float scale)
+    : ModelOpMatmul(input, other, output, trans_input, trans_other) {
+    type_ = ModelOpT::from_name("MatmulScale");
+    args_["Scale"] = scale;
+}
+
+std::string ModelOpMatmulScale::impl_name(const Json &config) const {
+    // Reuse parent impl_name but replace "matmul" with "matmul_scale"
+    // and append scale factor as a template parameter
+    std::string name = ModelOpMatmul::impl_name(config);
+    float scale = args_.at("Scale").value<float>();
+    if (name.substr(0, 7) == "matmul<") {
+        // Insert scale parameter: matmul_scale<..., ScaleBits>
+        // Encode scale as integer bits for template parameter
+        union { float f; uint32_t u; } conv;
+        conv.f = scale;
+        name = "matmul_scale<" + name.substr(7);
+        // Remove trailing ">" and add scale bits
+        name = name.substr(0, name.size() - 1) + ", " + std::to_string(conv.u) + ">";
+    }
+    return name;
+}
+
+Tensor Model::matmul_scale(Tensor input, Tensor other, float scale,
+                           Tensor output, bool trans_input, bool trans_other,
+                           const std::string &name) {
+    return impl_
+        ->create_op<ModelOpMatmulScale>(name, input.ref(), other.ref(),
+                                        output.ref(), trans_input, trans_other,
+                                        scale)
+        ->result_tensors()[0];
+}
+
+ModelOpMatmulAdd::ModelOpMatmulAdd(ModelTensorRef input, ModelTensorRef other,
+                                   ModelTensorRef residual,
+                                   ModelTensorRef output, bool trans_input,
+                                   bool trans_other)
+    : ModelOp("MatmulAdd") {
+    Dims output_shape = calc_output_shape(input->shape(), other->shape(),
+                                          trans_input, trans_other);
+    Dims padded_output_shape = calc_output_shape(
+        input->padded_shape(), other->padded_shape(), trans_input, trans_other);
+    if (output) {
+        check_match_shape(output, output_shape);
+        check_match_padded_shape(output, padded_output_shape);
+    } else {
+        output = std::make_shared<ModelTensor>(
+            input->data_type(), std::make_shared<ModelBuffer>(), output_shape,
+            Dims{}, Dims{}, padded_output_shape);
+    }
+    // Residual must match output shape
+    check_match_shape(residual, output_shape);
+    check_match_padded_shape(residual, padded_output_shape);
+
+    ModelTensorRef result = std::make_shared<ModelTensor>(*output);
+
+    read_tensors_ = {input, other, residual};
+    write_tensors_ = {output};
+    result_tensors_ = {result};
+    args_["TransposeInput"] = trans_input;
+    args_["TransposeOther"] = trans_other;
+
+    verify();
+}
+
+std::string ModelOpMatmulAdd::impl_name(const Json &config) const {
+    check_fields_config(config, {"NumWarps", "SramBytes", "Tile"});
+    check_fields_args(args_, {"TransposeInput", "TransposeOther"});
+
+    bool trans_input = args_.at("TransposeInput").value<bool>();
+    bool trans_other = args_.at("TransposeOther").value<bool>();
+
+    const auto &input = read_tensors_[0];
+    const auto &other = read_tensors_[1];
+    const auto &output = result_tensors_[0];
+
+    Dims padded_problem_size = calc_problem_size(
+        input->padded_shape(), other->padded_shape(), trans_input, trans_other);
+    Dims output_shape = calc_output_shape(input->shape(), other->shape(),
+                                          trans_input, trans_other);
+    Dims padded_output_shape = calc_output_shape(
+        input->padded_shape(), other->padded_shape(), trans_input, trans_other);
+
+    Dims input_shape_dims4 = input->shape().dims4();
+    Dims other_shape_dims4 = other->shape().dims4();
+    Dims input_dim_nc{input_shape_dims4[0], input_shape_dims4[1]};
+    Dims other_dim_nc{other_shape_dims4[0], other_shape_dims4[1]};
+    Dims output_dim_nc = broadcast_shape(input_dim_nc, other_dim_nc);
+
+    Dims strides_acdb{
+        input->strides().dims4()[-1], output->strides().dims4()[-1],
+        output->strides().dims4()[-1], other->strides().dims4()[-1]};
+
+    int num_warps = config["NumWarps"];
+    int smem_bytes = config["SramBytes"];
+    Dims tile_shape = config["Tile"].get<std::vector<DimType>>();
+
+    DimType inner_stride_a;
+    DimType inner_stride_b;
+    if (trans_input) {
+        inner_stride_a = input->strides().dims4()[-2];
+    } else {
+        inner_stride_a = input->strides().dims4()[-1];
+    }
+    if (trans_other) {
+        inner_stride_b = other->strides().dims4()[-1];
+    } else {
+        inner_stride_b = other->strides().dims4()[-2];
+    }
+
+    DimType size_a = inner_stride_a * output->strides()[-2];
+    DimType size_b = inner_stride_b * output->strides()[-1];
+    DimType size_c = output->strides()[-2] * output->strides()[-1];
+    DimType batch_stride_c_a = input_dim_nc[1] == 1 ? 0 : size_a;
+    DimType batch_stride_n_a =
+        input_dim_nc[0] == 1 ? 0 : size_a * input_dim_nc[1];
+    DimType batch_stride_c_b = other_dim_nc[1] == 1 ? 0 : size_b;
+    DimType batch_stride_n_b =
+        other_dim_nc[0] == 1 ? 0 : size_b * other_dim_nc[1];
+    DimType batch_stride_c_c = output_dim_nc[1] == 1 ? 0 : size_c;
+    DimType batch_stride_n_c =
+        output_dim_nc[0] == 1 ? 0 : size_c * output_dim_nc[1];
+
+    return function_name_string("matmul_add",
+                                {
+                                    vec_string(output->strides().dims4()),
+                                    vec_string(input_dim_nc),
+                                    vec_string(other_dim_nc),
+                                    vec_string(tile_shape),
+                                    vec_string(padded_problem_size),
+                                    vec_string(strides_acdb),
+                                    std::to_string(batch_stride_n_a),
+                                    std::to_string(batch_stride_c_a),
+                                    std::to_string(batch_stride_n_b),
+                                    std::to_string(batch_stride_c_b),
+                                    std::to_string(batch_stride_n_c),
+                                    std::to_string(batch_stride_c_c),
+                                    std::to_string(trans_input),
+                                    std::to_string(trans_other),
+                                    std::to_string(num_warps),
+                                    std::to_string(smem_bytes),
+                                });
+}
+
+std::vector<ModelOpArg> ModelOpMatmulAdd::impl_args(
+    [[maybe_unused]] const Json &config) const {
+    // Args: output, input A, input B, residual
+    return {result_tensors_[0], read_tensors_[0], read_tensors_[1],
+            read_tensors_[2]};
+}
+
+Json ModelOpMatmulAdd::default_config(const ArchRef arch) const {
+    check_fields_args(args_, {"TransposeInput", "TransposeOther"});
+    Dims mnk = calc_problem_size(read_tensors_[0]->padded_shape(),
+                                 read_tensors_[1]->padded_shape(),
+                                 args_.at("TransposeInput").value<bool>(),
+                                 args_.at("TransposeOther").value<bool>());
+    return get_default_config(arch, result_tensors_[0]->data_type(), mnk);
+}
+
+Tensor Model::matmul_add(Tensor input, Tensor other, Tensor residual,
+                         Tensor output, bool trans_input, bool trans_other,
+                         const std::string &name) {
+    return impl_
+        ->create_op<ModelOpMatmulAdd>(name, input.ref(), other.ref(),
+                                      residual.ref(), output.ref(),
+                                      trans_input, trans_other)
+        ->result_tensors()[0];
+}
+
+Tensor Model::mma(Tensor input, Tensor other, Tensor output,
+                     bool trans_input, bool trans_other,
+                     const std::string &name) {
+    return impl_
+        ->create_op<ModelOpMma>(name, input.ref(), other.ref(), output.ref(),
+                                trans_input, trans_other)
+        ->result_tensors()[0];
+}
+
+// ---- Mma: matmul with REGISTER output tensor ----
+
+ModelOpMma::ModelOpMma(ModelTensorRef input, ModelTensorRef other,
+                       ModelTensorRef output, bool trans_input,
+                       bool trans_other)
+    : ModelOpMatmul(input, other, output, trans_input, trans_other) {
+    type_ = ModelOpT::from_name("Mma");
+    // Tag the output tensor as REGISTER location
+    for (auto &t : result_tensors_) {
+        t->set_location(TensorLocation::REGISTER);
+    }
+    for (auto &t : write_tensors_) {
+        t->set_location(TensorLocation::REGISTER);
+    }
+}
+
+std::string ModelOpMma::impl_name(const Json &config) const {
+    // Currently uses the same kernel as matmul.
+    // When codegen supports REGISTER tensors, this will generate
+    // MMA-only code (no epilogue store).
+    return ModelOpMatmul::impl_name(config);
+}
+
+
+Tensor Model::store(Tensor output, Tensor input, const std::string &name) {
+    return impl_
+        ->create_op<ModelOpStore>(name, input.ref(), output.ref())
+        ->result_tensors()[0];
+}
+
+// ---- Store: write register tensor to global memory ----
+
+ModelOpStore::ModelOpStore(ModelTensorRef input, ModelTensorRef output)
+    : ModelOpCopy(input, output) {
+    type_ = ModelOpT::from_name("Store");
+    // Ensure output is GLOBAL location
+    for (auto &t : result_tensors_) {
+        t->set_location(TensorLocation::GLOBAL);
+    }
+    for (auto &t : write_tensors_) {
+        t->set_location(TensorLocation::GLOBAL);
+    }
+}
+
+std::string ModelOpStore::impl_name(const Json &config) const {
+    // Use "copy" kernel, not "store" (clashes with ark::store in load_store.h).
+    // When codegen handles REGISTER tensors, this will be replaced with
+    // epilogue-only code generation.
+    check_fields_config(config, {"NumWarps", "Tile"});
+    int num_warps = config.at("NumWarps");
+    Dims unit_out_dims(config.at("Tile").get<std::vector<DimType>>());
+    return function_name_string(
+        "copy",
+        {vec_string(read_tensors_[0]->strides().dims4()),
+         vec_string(read_tensors_[0]->shape().dims4()),
+         vec_string(write_tensors_[0]->strides().dims4()),
+         vec_string(write_tensors_[0]->shape().dims4()),
+         vec_string(unit_out_dims.dims4()),
+         std::to_string(num_warps),
+         "0"});
+}
+
+
 
 }  // namespace ark

--- a/ark/ops/ops_matmul.cpp
+++ b/ark/ops/ops_matmul.cpp
@@ -333,6 +333,8 @@ std::string ModelOpMatmulGelu::impl_name(const Json &config) const {
     // The name starts with "matmul<" — replace prefix
     if (name.substr(0, 7) == "matmul<") {
         name = "matmul_gelu<" + name.substr(7);
+    } else {
+        ERR(InvalidStateError, "unexpected matmul impl_name format: ", name);
     }
     return name;
 }
@@ -369,6 +371,8 @@ std::string ModelOpMatmulScale::impl_name(const Json &config) const {
         name = "matmul_scale<" + name.substr(7);
         // Remove trailing ">" and add scale bits
         name = name.substr(0, name.size() - 1) + ", " + std::to_string(conv.u) + ">";
+    } else {
+        ERR(InvalidStateError, "unexpected matmul impl_name format: ", name);
     }
     return name;
 }
@@ -400,9 +404,15 @@ ModelOpMatmulAdd::ModelOpMatmulAdd(ModelTensorRef input, ModelTensorRef other,
             input->data_type(), std::make_shared<ModelBuffer>(), output_shape,
             Dims{}, Dims{}, padded_output_shape);
     }
-    // Residual must match output shape
+    // Residual must match output shape and strides
     check_match_shape(residual, output_shape);
     check_match_padded_shape(residual, padded_output_shape);
+    if (residual->strides() != output->strides()) {
+        ERR(InvalidUsageError,
+            "MatmulAdd requires residual and output to have matching strides. "
+            "Residual strides: ", residual->strides(),
+            ", output strides: ", output->strides());
+    }
 
     ModelTensorRef result = std::make_shared<ModelTensor>(*output);
 
@@ -424,7 +434,12 @@ std::string ModelOpMatmulAdd::impl_name(const Json &config) const {
 
     const auto &input = read_tensors_[0];
     const auto &other = read_tensors_[1];
+    const auto &residual = read_tensors_[2];
     const auto &output = result_tensors_[0];
+
+    check_match_data_type(input, other);
+    check_match_data_type(input, output);
+    check_match_data_type(input, residual);
 
     Dims padded_problem_size = calc_problem_size(
         input->padded_shape(), other->padded_shape(), trans_input, trans_other);
@@ -472,6 +487,25 @@ std::string ModelOpMatmulAdd::impl_name(const Json &config) const {
     DimType batch_stride_c_c = output_dim_nc[1] == 1 ? 0 : size_c;
     DimType batch_stride_n_c =
         output_dim_nc[0] == 1 ? 0 : size_c * output_dim_nc[1];
+
+    if (config.contains("BatchStrideNA")) {
+        batch_stride_n_a = config["BatchStrideNA"].get<DimType>();
+    }
+    if (config.contains("BatchStrideCA")) {
+        batch_stride_c_a = config["BatchStrideCA"].get<DimType>();
+    }
+    if (config.contains("BatchStrideNB")) {
+        batch_stride_n_b = config["BatchStrideNB"].get<DimType>();
+    }
+    if (config.contains("BatchStrideCB")) {
+        batch_stride_c_b = config["BatchStrideCB"].get<DimType>();
+    }
+    if (config.contains("BatchStrideNC")) {
+        batch_stride_n_c = config["BatchStrideNC"].get<DimType>();
+    }
+    if (config.contains("BatchStrideCC")) {
+        batch_stride_c_c = config["BatchStrideCC"].get<DimType>();
+    }
 
     return function_name_string("matmul_add",
                                 {
@@ -530,6 +564,7 @@ Tensor Model::mma(Tensor input, Tensor other, Tensor output,
 }
 
 // ---- Mma: matmul with REGISTER output tensor ----
+// See TensorLocation::REGISTER TODO in model_tensor.hpp
 
 ModelOpMma::ModelOpMma(ModelTensorRef input, ModelTensorRef other,
                        ModelTensorRef output, bool trans_input,
@@ -560,6 +595,7 @@ Tensor Model::store(Tensor output, Tensor input, const std::string &name) {
 }
 
 // ---- Store: write register tensor to global memory ----
+// See TensorLocation::REGISTER TODO in model_tensor.hpp
 
 ModelOpStore::ModelOpStore(ModelTensorRef input, ModelTensorRef output)
     : ModelOpCopy(input, output) {

--- a/ark/ops/ops_matmul.hpp
+++ b/ark/ops/ops_matmul.hpp
@@ -5,6 +5,7 @@
 #define ARK_OPS_MATMUL_HPP_
 
 #include "model/model_op.hpp"
+#include "ops_copy.hpp"
 
 namespace ark {
 
@@ -19,6 +20,74 @@ class ModelOpMatmul : public ModelOp {
     std::vector<ModelOpArg> impl_args(const Json &config) const override;
 
     Json default_config(const ArchRef arch = ARCH_ANY) const override;
+};
+
+/// Matmul with GELU activation fused into the CUTLASS epilogue.
+/// Output = gelu(input @ other). Same interface as ModelOpMatmul.
+class ModelOpMatmulGelu : public ModelOpMatmul {
+   public:
+    ModelOpMatmulGelu() = default;
+    ModelOpMatmulGelu(ModelTensorRef input, ModelTensorRef other,
+                      ModelTensorRef output, bool trans_input,
+                      bool trans_other);
+
+    std::string impl_name(const Json &config) const override;
+};
+
+/// Matmul with residual addition: output = input @ other + residual.
+/// The residual tensor is added via CUTLASS beta=1 epilogue.
+class ModelOpMatmulAdd : public ModelOp {
+   public:
+    ModelOpMatmulAdd() = default;
+    ModelOpMatmulAdd(ModelTensorRef input, ModelTensorRef other,
+                     ModelTensorRef residual, ModelTensorRef output,
+                     bool trans_input, bool trans_other);
+
+    std::string impl_name(const Json &config) const override;
+
+    std::vector<ModelOpArg> impl_args(const Json &config) const override;
+
+    Json default_config(const ArchRef arch = ARCH_ANY) const override;
+};
+
+/// Matmul with scale applied on register accumulators before epilogue.
+/// Output = (input @ other) * scale. The scale is fused into the CUTLASS
+/// accumulator registers, eliminating a separate global memory round-trip.
+class ModelOpMatmulScale : public ModelOpMatmul {
+   public:
+    ModelOpMatmulScale() = default;
+    ModelOpMatmulScale(ModelTensorRef input, ModelTensorRef other,
+                       ModelTensorRef output, bool trans_input,
+                       bool trans_other, float scale);
+
+    std::string impl_name(const Json &config) const override;
+};
+
+/// MMA op: matmul that produces a REGISTER tensor.
+/// Currently behaves identically to Matmul but tags the output with
+/// TensorLocation::REGISTER. When codegen detects a REGISTER output
+/// followed by elementwise ops in the same sync=False block, it can
+/// fuse them at the register level.
+class ModelOpMma : public ModelOpMatmul {
+   public:
+    ModelOpMma() = default;
+    ModelOpMma(ModelTensorRef input, ModelTensorRef other,
+               ModelTensorRef output, bool trans_input, bool trans_other);
+
+    std::string impl_name(const Json &config) const override;
+};
+
+/// Store op: write a register tensor to global memory.
+/// This marks the end of a register-level fusion chain.
+/// When codegen detects mma → elementwise → store within a sync=False block,
+/// it generates a single gemm_with_functor kernel.
+/// Currently implemented as a no-op (the output IS the input buffer).
+class ModelOpStore : public ModelOpCopy {
+   public:
+    ModelOpStore() = default;
+    ModelOpStore(ModelTensorRef input, ModelTensorRef output);
+    // Override to use "copy" kernel (not "store" which clashes with load_store.h)
+    std::string impl_name(const Json &config) const override;
 };
 
 }  // namespace ark


### PR DESCRIPTION
- Add TensorLocation enum (GLOBAL/SHARED/REGISTER) to ModelTensor
- Add CUTLASS GEMM fused epilogue: gemm_with_functor<F> template + FunctorScale, FunctorGelu, FunctorScaleExp, FunctorAdd
- New ops: ModelOpMatmulScale, ModelOpMatmulGelu, ModelOpMma, ModelOpStore
- matmul_scale fuses attention Q@K^T/sqrt(dk) into one kernel
- matmul_gelu fuses FFN1 linear+GELU into one kernel
- mma/store provide register-tagged output for future fusion