### PR TITLE
Add BASE_IMAGE usage comments to Dockerfiles

### DIFF
--- a/docker/base-dev-x.dockerfile
+++ b/docker/base-dev-x.dockerfile
@@ -1,3 +1,6 @@
+# Default BASE_IMAGE allows standalone `docker build`.
+# When using build.sh, this is overridden via --build-arg
+# with the target-specific base image (e.g. ark:base-cuda12.1).
 ARG BASE_IMAGE=ghcr.io/microsoft/ark/ark:base-cuda12.1
 FROM ${BASE_IMAGE}
 

--- a/docker/base-dev-x.dockerfile
+++ b/docker/base-dev-x.dockerfile
@@ -1,6 +1,5 @@
 # Default BASE_IMAGE allows standalone `docker build`.
-# When using build.sh, this is overridden via --build-arg
-# with the target-specific base image (e.g. ark:base-cuda12.1).
+# build.sh overrides this via --build-arg for each target.
 ARG BASE_IMAGE=ghcr.io/microsoft/ark/ark:base-cuda12.1
 FROM ${BASE_IMAGE}
 

--- a/docker/base-x.dockerfile
+++ b/docker/base-x.dockerfile
@@ -1,3 +1,5 @@
+# Default BASE_IMAGE allows standalone `docker build`.
+# build.sh overrides this via --build-arg for each target.
 ARG BASE_IMAGE=nvidia/cuda:12.1.1-devel-ubuntu20.04
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
Add BASE_IMAGE usage comments to Dockerfiles

Document the `ARG BASE_IMAGE` default/override pattern in
`base-dev-x.dockerfile` and `base-x.dockerfile`. `build.sh` overrides the
default via `--build-arg` for each target; the default exists so standalone
`docker build` works without `--build-arg`. Comments make this relationship
explicit.

Extracted from PR #242. That PR removed the defaults entirely, which would
break standalone builds; this PR keeps defaults and adds documentation
instead. Functional package additions (clang-format, torch, black) deferred
as optional follow-up.

Files changed:
- `docker/base-dev-x.dockerfile` — 3-line comment added (lines 1–3)
- `docker/base-x.dockerfile` — 2-line comment added (lines 1–2)

No functional changes. No Docker CI exists; hadolint clean.